### PR TITLE
Resolve audit-worthy runtime and CLI issues

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4323,6 +4323,11 @@ pub fn build(b: *std.Build) void {
         "test-suites",
         "Restrict `zig build test` to exact suite ids; README lists ids and invalid ids print them.",
     );
+    const lint_verbose = b.option(
+        bool,
+        "lint-verbose",
+        "Print verbose zlinter command output during `zig build lint`.",
+    ) orelse false;
     const test_requested_from_argv = buildInvocationRequestsRunnableStep("test");
     const lint_requested_from_argv = buildInvocationRequestsStep("lint");
     const inferred_shared_tail = inferBuildInvocationFromSharedTail(b.args);
@@ -4890,6 +4895,8 @@ pub fn build(b: *std.Build) void {
     const run_ability_agent_vm_fixture = b.addRunArtifact(ability_agent_vm_fixture_exe);
     if (fixture_tail_args.len != 0) {
         run_ability_agent_vm_fixture.addArgs(fixture_tail_args);
+    } else {
+        run_ability_agent_vm_fixture.addArg("--write");
     }
     const ability_agent_vm_fixture_step = b.step(
         "generate-ability-agent-vm-fixture",
@@ -5596,7 +5603,7 @@ pub fn build(b: *std.Build) void {
         const saved_args = b.args;
         const lint_args = repoZigLintCliArgsAlloc(b, lint_shared_tail_args);
         defer b.allocator.free(lint_args);
-        b.verbose = true;
+        b.verbose = saved_verbose or lint_verbose;
         b.args = lint_args;
         defer {
             b.verbose = saved_verbose;

--- a/src/ability_agent_vm.zig
+++ b/src/ability_agent_vm.zig
@@ -573,18 +573,16 @@ fn cloneResumedResponse(
     value: host_api.ToolCallResultV1,
     bounds: host_api.DataValueBoundsV1,
 ) !host.Resumed {
-    const tool_id = try allocator.dupe(u8, value.tool_id);
-    errdefer allocator.free(tool_id);
-    const cloned_value = try value.value.cloneBounded(allocator, bounds);
+    const cloned = try value.cloneBounded(allocator, bounds);
     errdefer {
-        var owned_value = cloned_value;
-        owned_value.deinit(allocator);
+        var owned = cloned;
+        owned.deinit(allocator);
     }
     return .{
         .request_id = request_id,
-        .tool_id = tool_id,
-        .call_id = value.call_id,
-        .value = cloned_value,
+        .tool_id = cloned.tool_id,
+        .call_id = cloned.call_id,
+        .value = cloned.value,
         .owns_tool_id = true,
         .value_ownership = .deep,
     };
@@ -596,18 +594,16 @@ fn cloneTerminalResponse(
     value: host_api.ToolCallResultV1,
     bounds: host_api.DataValueBoundsV1,
 ) !host.Terminal {
-    const tool_id = try allocator.dupe(u8, value.tool_id);
-    errdefer allocator.free(tool_id);
-    const cloned_value = try value.value.cloneBounded(allocator, bounds);
+    const cloned = try value.cloneBounded(allocator, bounds);
     errdefer {
-        var owned_value = cloned_value;
-        owned_value.deinit(allocator);
+        var owned = cloned;
+        owned.deinit(allocator);
     }
     return .{
         .request_id = request_id,
-        .tool_id = tool_id,
-        .call_id = value.call_id,
-        .value = cloned_value,
+        .tool_id = cloned.tool_id,
+        .call_id = cloned.call_id,
+        .value = cloned.value,
         .owns_tool_id = true,
         .value_ownership = .deep,
     };
@@ -638,25 +634,28 @@ fn cloneSuccessResult(
     if (value.request_id != request_id) {
         return invalidHostReplyResult(allocator, request_id, "host reply request_id must echo the request");
     }
-    const cloned_value = value.value.cloneBounded(allocator, bounds) catch |err| switch (err) {
+    const cloned = (host_api.ToolCallResultV1{
+        .tool_id = value.tool_id,
+        .call_id = value.call_id,
+        .control = control,
+        .value = value.value,
+    }).cloneBounded(allocator, bounds) catch |err| switch (err) {
         error.DataValueTooDeep, error.DataValueTooManyNodes, error.DataValueTooManyBytes => {
             return resourceExhaustedResult(allocator, request_id, "artifact host payload budget exceeded");
         },
         else => return err,
     };
     errdefer {
-        var owned_value = cloned_value;
-        owned_value.deinit(allocator);
+        var owned = cloned;
+        owned.deinit(allocator);
     }
-    const tool_id = try allocator.dupe(u8, value.tool_id);
-    errdefer allocator.free(tool_id);
     return .{
         .request_id = request_id,
         .body = .{ .success = .{
-            .tool_id = tool_id,
-            .call_id = value.call_id,
-            .control = control,
-            .value = cloned_value,
+            .tool_id = cloned.tool_id,
+            .call_id = cloned.call_id,
+            .control = cloned.control,
+            .value = cloned.value,
             .owns_tool_id = true,
             .value_ownership = .deep,
         } },
@@ -960,6 +959,29 @@ test "response bridge frees duplicated tool ids on allocation failure" {
         expectResponseBridgeClonesToolIdWithoutLeaksOnAllocationFailure,
         .{},
     );
+}
+
+test "response bridge charges success tool ids against payload byte bounds" {
+    var response: host.Response = .{ .resumed = .{
+        .request_id = 41,
+        .tool_id = "generated/tooling@v1",
+        .call_id = 7,
+        .value = .null,
+    } };
+    defer response.deinit(std.testing.allocator);
+
+    var bridged = try responseToInternal(std.testing.allocator, 41, response, .{
+        .max_bytes = 1,
+    });
+    defer bridged.deinit(std.testing.allocator);
+
+    switch (bridged.body) {
+        .failed => |failure| {
+            try std.testing.expectEqualStrings("resource_exhausted", failure.code);
+            try std.testing.expectEqualStrings("artifact host payload budget exceeded", failure.message);
+        },
+        else => return error.TestUnexpectedResponseKind,
+    }
 }
 
 test "output bridge validates snapshot count before cloning payloads" {

--- a/src/artifact_vm_runtime.zig
+++ b/src/artifact_vm_runtime.zig
@@ -69,10 +69,12 @@ pub const RunArtifactResultV1 = union(enum) {
     }
 };
 
+const default_max_artifact_bytes = 16 * 1024 * 1024;
 const default_max_log_bytes = 16 * 1024 * 1024;
 
 /// Resource envelope for synchronous ArtifactV1 execution.
 pub const RunOptionsV1 = struct {
+    max_artifact_bytes: usize = default_max_artifact_bytes,
     max_block_steps: usize = 100_000,
     max_instruction_steps: usize = 1_000_000,
     max_host_calls: usize = 100_000,
@@ -99,6 +101,7 @@ pub fn runArtifactWithOptions(
     adapter: host.HostAdapterV1,
     options: RunOptionsV1,
 ) anyerror!RunArtifactResultV1 {
+    if (bytes.len > options.max_artifact_bytes) return try invalidArtifactResult(allocator, error.ArtifactTooLarge);
     var decoded_with_plan = artifact.decodeWithProgramPlan(allocator, bytes) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return try invalidArtifactResult(allocator, err),
@@ -1435,6 +1438,37 @@ test "artifact runtime fails closed when block budget is exhausted" {
             defer failure.deinit(allocator);
             try std.testing.expectEqualStrings("resource_exhausted", failure.code);
             try std.testing.expectEqualStrings("artifact block budget exceeded", failure.message);
+        },
+        else => return error.TestUnexpectedRuntimeResult,
+    }
+}
+
+test "artifact runtime rejects artifacts above configured decode byte budget before dispatch" {
+    const allocator = std.testing.allocator;
+    const bytes = [_]u8{0} ** 2;
+    const adapter = host.HostAdapterV1{
+        .ctx = null,
+        .dispatchFn = struct {
+            fn dispatch(
+                _: ?*anyopaque,
+                _: std.mem.Allocator,
+                _: host.HostEffectRequestV1,
+            ) anyerror!host.HostEffectResultV1 {
+                return error.TestUnexpectedDispatch;
+            }
+        }.dispatch,
+    };
+
+    var result = try runArtifactWithOptions(allocator, &bytes, adapter, .{
+        .max_artifact_bytes = 1,
+    });
+    defer result.deinit(allocator);
+
+    switch (result) {
+        .rejected => |rejected| {
+            try std.testing.expectEqualStrings("invalid_artifact", rejected.failure.code);
+            try std.testing.expectEqualStrings("ArtifactTooLarge", rejected.failure.message);
+            try std.testing.expectEqual(@as(usize, 0), rejected.logs.len);
         },
         else => return error.TestUnexpectedRuntimeResult,
     }

--- a/src/private_modules/artifact_vm_runtime_build.zig
+++ b/src/private_modules/artifact_vm_runtime_build.zig
@@ -69,10 +69,12 @@ pub const RunArtifactResultV1 = union(enum) {
     }
 };
 
+const default_max_artifact_bytes = 16 * 1024 * 1024;
 const default_max_log_bytes = 16 * 1024 * 1024;
 
 /// Resource envelope for synchronous ArtifactV1 execution.
 pub const RunOptionsV1 = struct {
+    max_artifact_bytes: usize = default_max_artifact_bytes,
     max_block_steps: usize = 100_000,
     max_instruction_steps: usize = 1_000_000,
     max_host_calls: usize = 100_000,
@@ -99,6 +101,7 @@ pub fn runArtifactWithOptions(
     adapter: host.HostAdapterV1,
     options: RunOptionsV1,
 ) anyerror!RunArtifactResultV1 {
+    if (bytes.len > options.max_artifact_bytes) return try invalidArtifactResult(allocator, error.ArtifactTooLarge);
     var decoded_with_plan = artifact.decodeWithProgramPlan(allocator, bytes) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         else => return try invalidArtifactResult(allocator, err),
@@ -1435,6 +1438,37 @@ test "artifact runtime fails closed when block budget is exhausted" {
             defer failure.deinit(allocator);
             try std.testing.expectEqualStrings("resource_exhausted", failure.code);
             try std.testing.expectEqualStrings("artifact block budget exceeded", failure.message);
+        },
+        else => return error.TestUnexpectedRuntimeResult,
+    }
+}
+
+test "artifact runtime rejects artifacts above configured decode byte budget before dispatch" {
+    const allocator = std.testing.allocator;
+    const bytes = [_]u8{0} ** 2;
+    const adapter = host.HostAdapterV1{
+        .ctx = null,
+        .dispatchFn = struct {
+            fn dispatch(
+                _: ?*anyopaque,
+                _: std.mem.Allocator,
+                _: host.HostEffectRequestV1,
+            ) anyerror!host.HostEffectResultV1 {
+                return error.TestUnexpectedDispatch;
+            }
+        }.dispatch,
+    };
+
+    var result = try runArtifactWithOptions(allocator, &bytes, adapter, .{
+        .max_artifact_bytes = 1,
+    });
+    defer result.deinit(allocator);
+
+    switch (result) {
+        .rejected => |rejected| {
+            try std.testing.expectEqualStrings("invalid_artifact", rejected.failure.code);
+            try std.testing.expectEqualStrings("ArtifactTooLarge", rejected.failure.message);
+            try std.testing.expectEqual(@as(usize, 0), rejected.logs.len);
         },
         else => return error.TestUnexpectedRuntimeResult,
     }

--- a/src/source_lowering.zig
+++ b/src/source_lowering.zig
@@ -17,6 +17,101 @@ pub const SurfaceKind = enum {
     witness,
 };
 
+const source_case_ids = [_][]const u8{
+    "source.local_mutation_resume",
+    "source.branch_resume",
+    "source.loop_resume",
+    "source.helper_call_resume",
+    "source.nested_prompt_static_redelim",
+    "source.typed_error_try",
+    "source.defer_resume",
+    "source.errdefer_error",
+};
+
+const example_case_ids = [_][]const u8{
+    "example.open_row_transform_basic",
+    "example.open_row_choice_basic",
+    "example.open_row_abort_basic",
+    "example.open_row_workflow",
+    "example.open_row_abortive_validation",
+    "example.open_row_artifact_search",
+    "example.open_row_generator",
+    "example.early_exit",
+    "example.resume_or_return",
+    "example.nested_workflow",
+    "example.state_basic",
+    "example.reader_basic",
+    "example.optional_basic",
+    "example.exception_basic",
+    "example.resource_basic",
+    "example.writer_basic",
+};
+
+const effect_case_ids = [_][]const u8{
+    "effect.state_basic",
+    "effect.reader_basic",
+    "effect.optional_basic",
+    "effect.exception_basic",
+    "effect.resource_basic",
+    "effect.writer_basic",
+};
+
+const user_defined_case_ids = [_][]const u8{
+    "user_defined.transform",
+    "user_defined.choice",
+    "user_defined.abort",
+};
+
+const witness_case_ids = [_][]const u8{
+    "witness.atm_resume_transform",
+    "witness.direct_return",
+    "witness.multi_prompt",
+    "witness.resume_or_return_return_now",
+    "witness.resume_or_return_resume",
+    "witness.static_redelim",
+    "witness.generator",
+};
+
+/// Return supported source-lowering case ids for one CLI surface.
+pub fn supportedCaseIds(surface_kind: SurfaceKind) []const []const u8 {
+    return switch (surface_kind) {
+        .source_case => source_case_ids[0..],
+        .example => example_case_ids[0..],
+        .effect => effect_case_ids[0..],
+        .user_defined_effect => user_defined_case_ids[0..],
+        .witness => witness_case_ids[0..],
+    };
+}
+
+fn caseIdListContains(ids: []const []const u8, needle: []const u8) bool {
+    for (ids) |id| {
+        if (std.mem.eql(u8, id, needle)) return true;
+    }
+    return false;
+}
+
+test "supported case-id listings stay aligned with admitted cases" {
+    for (source_registry.cases) |case| {
+        try std.testing.expect(caseIdListContains(supportedCaseIds(.source_case), case.case_id));
+    }
+    for (shipped_open_row_corpus.custom_examples) |row| {
+        try std.testing.expect(caseIdListContains(supportedCaseIds(.example), row.example_case_id));
+        if (row.user_defined_case_id) |case_id| {
+            try std.testing.expect(caseIdListContains(supportedCaseIds(.user_defined_effect), case_id));
+        }
+    }
+    inline for (@typeInfo(SurfaceKind).@"enum".fields) |field| {
+        const surface_kind: SurfaceKind = @enumFromInt(field.value);
+        for (supportedCaseIds(surface_kind)) |case_id| {
+            const supported = switch (surface_kind) {
+                .source_case => source_registry.find(case_id) != null,
+                .example, .effect, .user_defined_effect, .witness => promotedSupportedCase(case_id, surface_kind) != null,
+            };
+            try std.testing.expect(supported);
+        }
+    }
+}
+
 /// Progress state for one source-lowering result.
 pub const LowerStatus = authoring_lowerer.LowerStatus;
 
@@ -856,6 +951,25 @@ fn generatedEntrySymbolMismatchProgram(
     return program;
 }
 
+fn generatedCanonicalSourceDriftProgram(
+    allocator: std.mem.Allocator,
+    spec: Spec,
+    case: SupportedCase,
+) std.mem.Allocator.Error!GeneratedProgram {
+    const message = try std.fmt.allocPrint(
+        allocator,
+        "source differs from the registered artifact layout for this case; rerun with --source {s}, or update the case registry and baseline before rerunning",
+        .{case.source_path},
+    );
+    errdefer allocator.free(message);
+    const owned_messages = try allocator.alloc([]const u8, 1);
+    errdefer allocator.free(owned_messages);
+    owned_messages[0] = message;
+    var program = try generatedRejectedProgram(allocator, spec, case, "canonical_source_drift", message);
+    program.owned_diagnostic_messages = owned_messages;
+    return program;
+}
+
 fn inspectSourceText(
     allocator: std.mem.Allocator,
     spec: Spec,
@@ -887,7 +1001,7 @@ fn inspectSourceText(
     if (lowered.status != .rejected and !(try sourceMatchesCanonicalLayout(allocator, case, source_text))) {
         lowered.deinit(allocator);
         lowered_owned = false;
-        return generatedRejectedProgram(allocator, spec, case, "canonical_source_drift", "source differs from the registered artifact layout for this case; use the registered source file or update the case registry and baseline before rerunning");
+        return generatedCanonicalSourceDriftProgram(allocator, spec, case);
     }
     const program = try generatedProgramFromLowered(allocator, spec, case, lowered);
     lowered_owned = false;
@@ -921,7 +1035,7 @@ fn inspectFileBackedSourceText(
     if (lowered.status != .rejected and !(try sourceMatchesCanonicalLayout(allocator, case, source_text))) {
         lowered.deinit(allocator);
         lowered_owned = false;
-        return generatedRejectedProgram(allocator, spec, case, "canonical_source_drift", "source differs from the registered artifact layout for this case; use the registered source file or update the case registry and baseline before rerunning");
+        return generatedCanonicalSourceDriftProgram(allocator, spec, case);
     }
     const program = try generatedProgramFromLowered(allocator, spec, case, lowered);
     lowered_owned = false;
@@ -967,7 +1081,7 @@ pub fn inspectSource(allocator: std.mem.Allocator, spec: Spec) LowerError!Genera
         if (!(try sourceMatchesCanonicalLayout(allocator, case, source))) {
             lowered.deinit(allocator);
             lowered_owned = false;
-            return generatedRejectedProgram(allocator, spec, case, "canonical_source_drift", "source differs from the registered artifact layout for this case; use the registered source file or update the case registry and baseline before rerunning");
+            return generatedCanonicalSourceDriftProgram(allocator, spec, case);
         }
     }
     const program = try generatedProgramFromLowered(allocator, spec, case, lowered);

--- a/test/generate_ability_agent_vm_fixture.zig
+++ b/test/generate_ability_agent_vm_fixture.zig
@@ -16,13 +16,15 @@ fn isModeArg(arg: []const u8) bool {
     return std.mem.eql(u8, arg, "--help") or
         std.mem.eql(u8, arg, "-h") or
         std.mem.eql(u8, arg, "--check") or
+        std.mem.eql(u8, arg, "--write") or
         std.mem.eql(u8, arg, "--version");
 }
 
 fn modeFromArgs(args: []const [:0]const u8) !Mode {
-    if (args.len == 1) return .write;
+    if (args.len == 1) return .check;
     if (args.len == 2 and isModeArg(args[1])) {
         if (std.mem.eql(u8, args[1], "--check")) return .check;
+        if (std.mem.eql(u8, args[1], "--write")) return .write;
         if (std.mem.eql(u8, args[1], "--version")) return .version;
         return .help;
     }
@@ -39,10 +41,11 @@ fn invalidArg(args: []const [:0]const u8) ?[]const u8 {
 
 fn writeUsage(writer: anytype) !void {
     try writer.writeAll(
-        "usage: generate-ability-agent-vm-fixture [--check|--version|--help]\n" ++
+        "usage: generate-ability-agent-vm-fixture [--check|--write|--version|--help]\n" ++
             "\n" ++
             "flags:\n" ++
             "  --check        verify the committed fixture is current\n" ++
+            "  --write        regenerate the committed fixture\n" ++
             "  --version      print the tool version\n" ++
             "  --help, -h     print this help\n",
     );
@@ -139,8 +142,9 @@ pub fn main(init: std.process.Init) anyerror!void {
 }
 
 test "ability_agent_vm fixture generator args expose help and reject unknowns" {
-    try std.testing.expectEqual(Mode.write, try modeFromArgs(&.{"generate-ability-agent-vm-fixture"}));
+    try std.testing.expectEqual(Mode.check, try modeFromArgs(&.{"generate-ability-agent-vm-fixture"}));
     try std.testing.expectEqual(Mode.check, try modeFromArgs(&.{ "generate-ability-agent-vm-fixture", "--check" }));
+    try std.testing.expectEqual(Mode.write, try modeFromArgs(&.{ "generate-ability-agent-vm-fixture", "--write" }));
     try std.testing.expectEqual(Mode.version, try modeFromArgs(&.{ "generate-ability-agent-vm-fixture", "--version" }));
     try std.testing.expectEqual(Mode.help, try modeFromArgs(&.{ "generate-ability-agent-vm-fixture", "--help" }));
     try std.testing.expectEqual(Mode.help, try modeFromArgs(&.{ "generate-ability-agent-vm-fixture", "-h" }));

--- a/test/source_lowering_boundary_test.zig
+++ b/test/source_lowering_boundary_test.zig
@@ -458,6 +458,11 @@ test "inline source lowering rejects whitespace drift after accepted authoring a
 
     try std.testing.expect(!lowered.isAccepted());
     try std.testing.expectEqualStrings("canonical_source_drift", lowered.diagnostics[0].code);
+    try std.testing.expect(std.mem.find(
+        u8,
+        lowered.diagnostics[0].message,
+        "rerun with --source test/source_lowering_corpus/fixtures/branch_resume.zig",
+    ) != null);
 }
 
 test "file-backed inline source lowering accepts canonical repo-relative paths from subdirectories" {
@@ -540,6 +545,11 @@ test "file-backed inline source lowering rejects whitespace drift after accepted
 
     try std.testing.expect(!lowered.isAccepted());
     try std.testing.expectEqualStrings("canonical_source_drift", lowered.diagnostics[0].code);
+    try std.testing.expect(std.mem.find(
+        u8,
+        lowered.diagnostics[0].message,
+        "rerun with --source test/source_lowering_corpus/fixtures/branch_resume.zig",
+    ) != null);
 }
 
 test "file-backed inline source lowering preserves parse-error locations" {

--- a/tools/ability_source_lower.zig
+++ b/tools/ability_source_lower.zig
@@ -12,6 +12,7 @@ const EmitMode = enum {
 
 const usage_text =
     "usage: ability-source-lower --id <source.case> --source <path> --entry <symbol> --surface <source_case|example|effect|user_defined_effect|witness> --emit <json|zig> --out <path>\n" ++
+    "       ability-source-lower --list-cases [--surface <source_case|example|effect|user_defined_effect|witness>]\n" ++
     "\n" ++
     "flags:\n" ++
     "  --id <case>      source-lowering case id, for example source.branch_resume or example.state_basic\n" ++
@@ -20,13 +21,15 @@ const usage_text =
     "  --surface <kind> one of source_case, example, effect, user_defined_effect, witness\n" ++
     "  --emit <format>  one of json or zig\n" ++
     "  --out <path>     write only under zig-out, .zig-cache, or zig-cache; parent directories must already exist\n" ++
+    "  --list-cases     print supported case ids, optionally restricted by --surface\n" ++
     "  --version        print the tool version\n" ++
     "  --help, -h       print this help\n" ++
     "\n" ++
     "examples:\n" ++
     "  mkdir -p zig-out/source-lower\n" ++
-    "  ability-source-lower --id source.branch_resume --source test/source_lowering_corpus/fixtures/branch_resume.zig --entry run --surface source_case --emit json --out zig-out/source-lower/branch.json\n" ++
-    "  ability-source-lower --id example.state_basic --source examples/state_basic.zig --entry main --surface example --emit zig --out zig-out/source-lower/state.zig\n";
+    "  ./zig-out/bin/ability-source-lower --list-cases --surface example\n" ++
+    "  ./zig-out/bin/ability-source-lower --id source.branch_resume --source test/source_lowering_corpus/fixtures/branch_resume.zig --entry run --surface source_case --emit json --out zig-out/source-lower/branch.json\n" ++
+    "  ./zig-out/bin/ability-source-lower --id example.state_basic --source examples/state_basic.zig --entry main --surface example --emit zig --out zig-out/source-lower/state.zig\n";
 const expected_flag_value_pair_count = 6;
 const expected_arg_count = 1 + expected_flag_value_pair_count * 2;
 const generated_output_roots = [_][]const u8{
@@ -85,6 +88,35 @@ fn usageError(comptime fmt: []const u8, args: anytype) noreturn {
 
 fn writeUsage(writer: anytype) !void {
     try writer.writeAll(usage_text);
+}
+
+fn writeSupportedCaseIds(writer: anytype, surface_kind: source_lowering.SurfaceKind) !void {
+    try writer.print("{s}:\n", .{@tagName(surface_kind)});
+    for (source_lowering.supportedCaseIds(surface_kind)) |case_id| {
+        try writer.print("  {s}\n", .{case_id});
+    }
+}
+
+fn listCases(allocator: std.mem.Allocator, io: std.Io, args: []const []const u8) !void {
+    _ = allocator;
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(io, &stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    if (args.len == 2) {
+        inline for (@typeInfo(source_lowering.SurfaceKind).@"enum".fields, 0..) |field, index| {
+            if (index != 0) try stdout.writeByte('\n');
+            try writeSupportedCaseIds(stdout, @enumFromInt(field.value));
+        }
+        try stdout.flush();
+        return;
+    }
+    if (args.len == 4 and std.mem.eql(u8, args[2], "--surface")) {
+        const surface_kind = parseSurface(args[3]) orelse usageError("unsupported --surface value '{s}'", .{args[3]});
+        try writeSupportedCaseIds(stdout, surface_kind);
+        try stdout.flush();
+        return;
+    }
+    usageError("expected --list-cases or --list-cases --surface <kind>", .{});
 }
 
 fn isKnownFlag(flag: []const u8) bool {
@@ -686,6 +718,10 @@ pub fn main(init: std.process.Init) anyerror!void {
             return;
         }
     }
+    if (args.len >= 2 and std.mem.eql(u8, args[1], "--list-cases")) {
+        try listCases(allocator, init.io, args);
+        return;
+    }
     if (cliShapeIssue(args)) |issue| {
         switch (issue) {
             .missing_value => |flag| usageError("missing value for flag '{s}'", .{flag}),
@@ -745,8 +781,8 @@ pub fn main(init: std.process.Init) anyerror!void {
         .surface_kind = cli_options.surface_kind,
     }) catch |err| switch (err) {
         error.UnsupportedSourceCase => usageError(
-            "unsupported --id '{s}' for --surface '{s}'; try --id source.branch_resume with --surface source_case or --id example.state_basic with --surface example",
-            .{ cli_options.program_id, @tagName(cli_options.surface_kind) },
+            "unsupported --id '{s}' for --surface '{s}'; run `ability-source-lower --list-cases --surface {s}` to see valid ids",
+            .{ cli_options.program_id, @tagName(cli_options.surface_kind), @tagName(cli_options.surface_kind) },
         ),
         else => return err,
     };
@@ -809,8 +845,23 @@ test "usage text documents required flags and recovery examples" {
     try std.testing.expect(std.mem.find(u8, usage_text, "--entry <symbol>") != null);
     try std.testing.expect(std.mem.find(u8, usage_text, "--surface <kind>") != null);
     try std.testing.expect(std.mem.find(u8, usage_text, "--emit <format>") != null);
+    try std.testing.expect(std.mem.find(u8, usage_text, "--list-cases") != null);
+    try std.testing.expect(std.mem.find(u8, usage_text, "./zig-out/bin/ability-source-lower") != null);
     try std.testing.expect(std.mem.find(u8, usage_text, "source.branch_resume") != null);
     try std.testing.expect(std.mem.find(u8, usage_text, "example.state_basic") != null);
+}
+
+test "case listing prints supported ids for a selected surface" {
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+
+    try writeSupportedCaseIds(&output.writer, .example);
+    const bytes = try output.toOwnedSlice();
+    defer std.testing.allocator.free(bytes);
+
+    try std.testing.expect(std.mem.find(u8, bytes, "example:\n") != null);
+    try std.testing.expect(std.mem.find(u8, bytes, "example.state_basic") != null);
+    try std.testing.expect(std.mem.find(u8, bytes, "example.open_row_transform_basic") != null);
 }
 
 test "cli shape reports missing values before arity" {


### PR DESCRIPTION
## Summary
- Charge host success response `tool_id` metadata against payload bounds and reject oversized ArtifactV1 bytes before decode.
- Make `ability-source-lower` recovery self-discoverable with `--list-cases` and canonical source-drift diagnostics that name the expected `--source` path.
- Make fixture regeneration explicit at the tool boundary while preserving the build step write path, and keep `zig build lint` quiet unless `-Dlint-verbose=true` is requested.

## Adjudicated Worth Resolving
- Host bridge success `tool_id` must count against `DataValueBoundsV1`.
- Artifact runtime needs a decode admission byte budget before `decodeWithProgramPlan`.
- Source-lower CLI invalid-id recovery should point to discoverable supported case IDs.
- Canonical source drift diagnostics should include the registered canonical source path.
- Fixture generator should not silently write the committed fixture by default.
- `zig build lint` should not force verbose success output by default.

## Proof
- `zig build test -Dtest-suites=source-lowering-boundary,source-lowering-tool,ability-agent-vm-smoke,artifact-vm-runtime-build-host-log-budget --summary none`
- `zig test build.zig --test-filter "fixture generator shared-tail"`
- `zig build source-lower --summary none` plus direct `ability-source-lower --list-cases --surface example` and unsupported-id recovery check
- `zig build --summary none generate-ability-agent-vm-fixture -- --check`
- `zig fmt --check .`
- `zig build lint -- --max-warnings 0`
- `zig build`
- `zig build test --summary all` (309/309 tests passed)
- `zig build --summary none generate-ability-agent-vm-fixture`
- `zig build --summary none check-ability-agent-vm-fixture`
