### PR TITLE
Tighten audit diagnostics and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ const ability_dep = b.dependency("ability", .{
     .optimize = optimize,
 });
 const ability_mod = ability_dep.module("ability");
+exe.root_module.addImport("ability", ability_mod);
 ```
 
 For local dependency development, prefer Zig's package override flag:
@@ -190,7 +191,14 @@ iteration, but they are not additional test contracts:
 - `zig build run-*` for retained examples
 - `zig build source-lower` to build `./zig-out/bin/ability-source-lower`
   (`./zig-out/bin/ability-source-lower --help` prints the tool contract)
-- `zig build generate-ability-agent-vm-fixture`
+- `zig build check-ability-agent-vm-fixture` to verify the committed
+  compatibility artifact fixture is current
+- `zig build generate-ability-agent-vm-fixture` to regenerate the committed
+  compatibility artifact fixture
   (`zig build generate-ability-agent-vm-fixture -- --help` prints generator help)
-- `zig build bench*`
+- `zig build bench`
+- `zig build bench-first-suspend`
+- `zig build bench-state-effect`
+- `zig build bench-family-matrix`
+- `zig build bench-runtime-backends`
 - `zig build zprof-hotspots`

--- a/src/with_api.zig
+++ b/src/with_api.zig
@@ -1448,7 +1448,7 @@ fn tryRepoOwnedNamedCompiledWith(
         entry_symbol,
     ) == null) {
         @compileError(std.fmt.comptimePrint(
-            "ability.with could not compile this repo-owned named body; keep the body within supported lexical effect operations or simplify unsupported helpers: source={s} entry={s}",
+            "ability.with could not compile this source-backed named body; keep the body within supported lexical effect operations, simplify unsupported helpers, or provide a complete source witness: source={s} entry={s}",
             .{ source_path, entry_symbol },
         ));
     }
@@ -1456,7 +1456,7 @@ fn tryRepoOwnedNamedCompiledWith(
         HandlersType,
         Body,
         source_ref,
-        "ability.with repo-owned named body",
+        "ability.with source-backed named body",
         entry_symbol,
     );
     return try program_type.run(

--- a/tools/ability_source_lower.zig
+++ b/tools/ability_source_lower.zig
@@ -134,6 +134,7 @@ fn cliShapeIssue(args: []const []const u8) ?CliShapeIssue {
         const flag = args[idx];
         if (!isKnownFlag(flag)) return .{ .unknown_flag = flag };
         if (idx + 1 >= args.len) return .{ .missing_value = flag };
+        if (std.mem.startsWith(u8, args[idx + 1], "--")) return .{ .missing_value = flag };
     }
     if (args.len > expected_arg_count) return .{ .unexpected_arg_count = args.len - 1 };
     return null;
@@ -368,7 +369,7 @@ fn writeJsonContributors(writer: anytype, contributors: anytype) !void {
 fn writeRejectedProgramDiagnostics(writer: anytype, program: source_lowering.GeneratedProgram) !void {
     if (program.diagnostics.len == 0) {
         try writer.print(
-            "ability-source-lower: rejected {s}: no source diagnostic was emitted\n",
+            "ability-source-lower: rejected {s}: no source diagnostic was emitted; check that --id, --surface, --source, and --entry describe the same supported case, or run --list-cases --surface <kind>\n",
             .{program.case_id},
         );
         return;
@@ -870,6 +871,40 @@ test "cli shape reports missing values before arity" {
     try std.testing.expectEqualStrings("--id", issue.missing_value);
 }
 
+test "cli shape reports flag tokens in value position as missing values" {
+    const missing_id_value = [_][]const u8{
+        "ability-source-lower",
+        "--id",
+        "--source",
+        "test/source_lowering_corpus/fixtures/branch_resume.zig",
+        "--entry",
+        "run",
+        "--surface",
+        "source_case",
+        "--emit",
+        "json",
+        "--out",
+        "zig-out/source-lower/out.json",
+    };
+    try std.testing.expectEqualStrings("--id", cliShapeIssue(&missing_id_value).?.missing_value);
+
+    const missing_source_value = [_][]const u8{
+        "ability-source-lower",
+        "--id",
+        "source.branch_resume",
+        "--source",
+        "--entry",
+        "run",
+        "--surface",
+        "source_case",
+        "--emit",
+        "json",
+        "--out",
+        "zig-out/source-lower/out.json",
+    };
+    try std.testing.expectEqualStrings("--source", cliShapeIssue(&missing_source_value).?.missing_value);
+}
+
 test "cli shape lets missing required flags reach named diagnostics" {
     const args = [_][]const u8{
         "ability-source-lower",
@@ -1207,4 +1242,29 @@ test "rejected source-lower programs print structured diagnostics" {
     try std.testing.expect(std.mem.find(u8, bytes, "ability-source-lower:") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "entry_symbol_mismatch") != null);
     try std.testing.expect(std.mem.find(u8, bytes, "expected entry symbol 'run'") != null);
+}
+
+test "rejected source-lower programs without diagnostics include recovery guidance" {
+    const program = source_lowering.GeneratedProgram{
+        .case_id = "source.test",
+        .label = "source.test",
+        .source_path = "test.zig",
+        .surface_kind = .source_case,
+        .status = .rejected,
+        .canonical_scenario_id = null,
+        .expected_transcript = "",
+        .steps = &.{},
+        .feature_flags = &.{},
+        .diagnostics = &.{},
+        .error_witness = error_witness.ErrorWitnessV1.empty(.ordinary),
+    };
+
+    var output: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer output.deinit();
+    try writeRejectedProgramDiagnostics(&output.writer, program);
+    const bytes = try output.toOwnedSlice();
+    defer std.testing.allocator.free(bytes);
+
+    try std.testing.expect(std.mem.find(u8, bytes, "check that --id, --surface, --source, and --entry") != null);
+    try std.testing.expect(std.mem.find(u8, bytes, "--list-cases --surface <kind>") != null);
 }


### PR DESCRIPTION
## Summary
- reject speculative audit findings and fix the source-backed user-facing issues that survived adjudication
- make ability-source-lower report missing flag values before shifted unknown-flag errors
- add recovery guidance for no-diagnostic source-lower rejections
- clarify README consumer import wiring, fixture check/regeneration commands, and exact benchmark steps
- replace repo-owned wording in the public ability.with named-body compile path

## Proof
- zig build test -Dtest-suites=source-lowering-tool --summary none
- zig build source-lower --summary none
- zig build test -Dtest-suites=lexical-with --summary none
- ./zig-out/bin/ability-source-lower --id --source test/source_lowering_corpus/fixtures/branch_resume.zig --entry run --surface source_case --emit json --out zig-out/source-lower/out.json -> exit 1, stderr: missing value for flag '--id'
- zig fmt --check .
- git diff --check
- zig build lint -- --max-warnings 0
- zig build --summary none
- zig build generate-ability-agent-vm-fixture --summary none
- zig build check-ability-agent-vm-fixture --summary none
- zig build test --summary none

## Adjudication
Acted on concrete CLI/docs/copy issues. Deferred heavier performance and runtime memory findings because they need measurement/design work rather than blind cleanup.