### PR TITLE
Release v0.5.0 metadata

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "0.4.1",
+    .version = "0.5.0",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",


### PR DESCRIPTION
## Summary
- Bump `build.zig.zon` package version from `0.4.1` to `0.5.0` after the portable-v2 runtime-closure merge.
- Keep release tag publication deferred until this release-prep change is reviewed and merged.

## Proof
- `zig version`: `0.16.0`
- `zig fmt --check build.zig src examples test bench`: pass
- `zig fmt --check build.zig.zon`: pass
- `git diff --check`: pass
- `zig build --summary all`: pass
- `zig build test --summary all`: pass, 117/117 steps, 519/519 tests
- `zig build lint -- --max-warnings 0`: pass, no issues

## Scope
- branch: `feature/boundary-v0.5.0-release`
- head: `b770eb4e8985c45221f8b7b3be7a4e21d2d6e4a6`
- base: `main`

## Readiness
- PR mode: ready
- Reason: one-file release metadata patch with full release proof passing on current head.
- Caveats: release tag and archive verification still pending after review/merge.