### PR TITLE
Release Boundary v0.7.0 for StaticMachine

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "0.6.2",
+    .version = "0.7.0",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/conformance/v0/boundary/corpus.boundary.txt
+++ b/conformance/v0/boundary/corpus.boundary.txt
@@ -3,7 +3,7 @@ format: boundary-conformance-artifact-catalog-v0
 manifest_fingerprint: 0xc3f1f221d499a992
 protocol_manifest_sha256: sha256:7330714f4e2eae6c6036e5562d55619c461fdf444fb0564b11c1e3b232908a68
 public_surface_fingerprint: 0x5ebfffa8f7fb8b5b
-public_surface_sha256: sha256:e1484dce50512a19f1abdc840f308aed91be746b0e69b10d6b752525cde38310
+public_surface_sha256: sha256:2c012926ca4eb45118288ee11dc02736da70855af597f79cadd0d19d6acfda3a
 artifacts:
 - id: protocol-manifest
   path: conformance/v0/boundary/protocol-manifest.bin
@@ -11,7 +11,7 @@ artifacts:
   replay: zig build check-boundary-format-drift
 - id: public-surface
   path: conformance/v0/public-surface.boundary.txt
-  sha256: sha256:e1484dce50512a19f1abdc840f308aed91be746b0e69b10d6b752525cde38310
+  sha256: sha256:2c012926ca4eb45118288ee11dc02736da70855af597f79cadd0d19d6acfda3a
   replay: zig build check-boundary-public-surface
 
 validation:

--- a/conformance/v0/public-surface.boundary.txt
+++ b/conformance/v0/public-surface.boundary.txt
@@ -1,5 +1,5 @@
 Boundary v0 public surface
-package: boundary 0.6.2
+package: boundary 0.7.0
 manifest_format_version: 1
 manifest_fingerprint_version: 1
 manifest_fingerprint: 0xc3f1f221d499a992


### PR DESCRIPTION
## Phase

Boundary release gate between World Comptime v1 Phase 2 and World adoption.

## Summary

- Bump the Boundary package version from `0.6.2` to `0.7.0` after the reviewed StaticMachine merge in PR #127.
- Regenerate the Boundary v0 public-surface snapshot and conformance catalog checksum.
- Establish the immutable release identity World must adopt before its comptime application implementation can be reviewed.

## Compatibility

- Public API: no additional API change beyond the already merged StaticMachine surface.
- Format/ABI: no protocol-manifest, StaticMachine state-format, fingerprint-domain, or ABI change.
- Canonical bytes: the generated v0 public-surface version line and its catalog checksum change.
- v0 behavior: unchanged.
- v0 compatibility: unchanged.
- Application WASM bytes: not applicable in Boundary.
- Production default: unchanged.
- Retirement status: unchanged.

Boundary remains the Zig algebraic-effects frontend. StaticMachine remains an additional backend; no World policy semantics are introduced.

## Proof

- `zig version`: `0.16.0`
- `zig fmt --check build.zig build.zig.zon src examples test bench`: pass
- `zig build check-boundary-public-surface`: pass
- `zig build check-boundary-conformance-corpus`: pass
- `zig build check-boundary-static-machine`: pass
- `zig build check-boundary-static-machine-parity`: pass
- `zig build check-boundary-static-agent`: pass
- `zig build check-boundary-static-provider`: pass
- `zig build check --summary all`: pass
- `zig build test --summary all`: pass
- `zig build lint -- --max-warnings 0`: pass
- `git diff --check`: pass

The six World end-to-end oracle scenarios are not rerun by this metadata-only Boundary release; World owns those gates after adopting the reviewed tag.
