### PR TITLE
Publish the Boundary StaticMachine v1 release surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ The public package root is intentionally small:
 - `boundary.effect`
 - `boundary.ir`
 - `boundary.program`
+- `boundary.staticMachine`
+- `boundary.StaticMachineOptions`
 - `boundary.Runtime`
 
 `effect` defines the effect families. `ir` exposes the public ProgramPlan
 builder. `program` gives a reusable execution surface for one named compiled
-body. `Runtime` is the caller-owned local runtime used to run programs
-repeatedly.
+body. `staticMachine` turns that Program into a typed portable-state reducer for
+World Comptime v1. `StaticMachineOptions` fixes its state encoding, explicit
+world-port policy, resource limits, and optional debug metadata. `Runtime` is
+the caller-owned local runtime used to run programs repeatedly.
 
 Each concrete `Program` also exposes `Program.Evidence`, the canonical internal
 evidence kernel for versioned fingerprint domains, evidence refs, dependency
@@ -34,14 +38,6 @@ profile, replay recipe, and target certificate. See
 [docs/boundary_elaboration.md](docs/boundary_elaboration.md), plus
 [docs/boundary_normalization.md](docs/boundary_normalization.md) and
 [docs/world_surface.md](docs/world_surface.md).
-
-`Target.Module` packages that normalized semantic surface as a deterministic
-Certified Boundary Module image. Reference modules support compact same-target
-transfer; full modules support validation and inspection without the original
-comptime Target type; partial modules are fail-closed around explicit external
-dependencies. Boundary serializes the normalized semantic boundary as a module.
-World serializes execution timelines and supplies the world. See
-[docs/boundary_module.md](docs/boundary_module.md).
 
 ## Program
 
@@ -140,6 +136,38 @@ pub fn main() !void {
     // result.value == 42
 }
 ```
+
+### Portable static state
+
+The supported portable path reuses the same validated program type:
+
+```zig
+const Program = boundary.program("demo", Handlers, Body);
+const Machine = boundary.staticMachine(Program, .{
+    .state_encoding = .canonical_v1,
+    .world_ports = .explicit,
+    .maximum_frames = 64,
+    .maximum_state_bytes = 1 << 20,
+});
+```
+
+`Program.Session` is the local, host-driven execution surface. It owns live
+interpreter state tied to a caller-owned `boundary.Runtime`. Use it for direct
+Zig execution, inspection, and programs outside the StaticMachine v1 admitted
+domain.
+
+`boundary.staticMachine` is the World Comptime v1 deployment surface. Its
+generated `State` can be encoded with the canonical v1 codec, decoded in a fresh
+process or WASM instance, validated against the machine contract, and resumed
+without a live `Runtime`. It does not broaden Program semantics: construction
+fails at comptime when the Program uses a carrier, control shape, provider
+graph, cleanup hook, or resource bound that StaticMachine v1 cannot represent
+exactly.
+
+See [docs/static_machine.md](docs/static_machine.md) for the API and state
+contract, and
+[docs/static_machine_compatibility.md](docs/static_machine_compatibility.md)
+for the ABI v1 support and compatibility matrix.
 
 The label must be non-empty. `Program.Result` exposes `value`, `outputs`, and
 `deinit()`. `Program.Session` exposes the same plan as a host-driven loop:
@@ -645,6 +673,21 @@ the scalar public carrier; typed product and sum payloads and resumes use the
 existing `Body.value_schema_types` schema registry, including after-continuation
 values. Result, output, and cleanup rules are the same `Program.Result` rules
 used by `Program.run`.
+
+## Advanced compatibility: Certified Boundary Modules
+
+`Target.Module` packages a normalized semantic surface as a deterministic
+Certified Boundary Module image. Reference modules support compact same-target
+transfer; full modules support validation and inspection without the original
+comptime Target type; partial modules are fail-closed around explicit external
+dependencies. This loaded-module deployment surface remains available for
+advanced and compatibility use, but it is not the World Comptime v1 application
+path. New portable applications should use
+`boundary.program -> boundary.staticMachine -> world.application`.
+
+Boundary serializes the normalized semantic boundary as a module. World
+serializes execution timelines and supplies the world. See
+[docs/boundary_module.md](docs/boundary_module.md).
 
 ## Effects
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,7 @@ const boundary = @import("boundary");
 const Handlers = struct {
     authored: struct {
         pub fn dispatch(_: *const @This()) !i32 {
-            return 41;
-        }
-
-        pub fn afterDispatch(_: *const @This(), value: i32) !i32 {
-            return value + 1;
+            return 42;
         }
     },
 };
@@ -102,7 +98,7 @@ fn plan() boundary.ir.ProgramPlan {
         .instruction_count = @intCast(instructions.len),
     }};
     const requirements = [_]boundary.ir.plan.Requirement{.{ .label = "authored", .first_op = 0, .op_count = 1 }};
-    const ops = [_]boundary.ir.plan.Op{.{ .requirement_index = 0, .op_name = "authored", .mode = .transform, .payload_codec = .unit, .resume_codec = .i32, .has_after = true }};
+    const ops = [_]boundary.ir.plan.Op{.{ .requirement_index = 0, .op_name = "authored", .mode = .transform, .payload_codec = .unit, .resume_codec = .i32, .has_after = false }};
     const blocks = [_]boundary.ir.plan.Block{.{ .first_instruction = 0, .instruction_count = @intCast(instructions.len), .terminator_index = 0 }};
     const terminators = [_]boundary.ir.plan.Terminator{.{ .kind = .return_value }};
 

--- a/build.zig
+++ b/build.zig
@@ -1174,6 +1174,13 @@ pub fn build(b: *std.Build) void {
     });
     const run_release_archive_checker = b.addRunArtifact(release_archive_checker);
     run_release_archive_checker.addArg(b.graph.zig_exe);
+    const configured_global_cache_path = b.graph.global_cache_root.path orelse ".";
+    const release_global_cache_path = if (std.Io.Dir.path.isAbsolute(
+        configured_global_cache_path,
+    ))
+        configured_global_cache_path
+    else
+        b.pathFromRoot(configured_global_cache_path);
     const release_archive_path = b.option(
         []const u8,
         "boundary-release-archive",
@@ -1185,6 +1192,7 @@ pub fn build(b: *std.Build) void {
     } else {
         run_release_archive_checker.addArg("");
     }
+    run_release_archive_checker.addArg(release_global_cache_path);
     const release_archive_once_step = b.step(
         "check-boundary-static-machine-release-archive-once",
         "Run one current-byte Boundary v0.7.0 materialized archive identity check.",
@@ -1203,6 +1211,7 @@ pub fn build(b: *std.Build) void {
         archive_cache_falsifier.addArg(b.graph.zig_exe);
         archive_cache_falsifier.addDirectoryArg(b.path("."));
         archive_cache_falsifier.addArg(archive_path);
+        archive_cache_falsifier.addArg(release_global_cache_path);
         archive_cache_falsifier.has_side_effects = true;
         release_archive_step.dependOn(&archive_cache_falsifier.step);
     }

--- a/build.zig
+++ b/build.zig
@@ -160,10 +160,11 @@ fn addCompileFailArtifact(
     compile_fail_step: *std.Build.Step,
     root_module: *std.Build.Module,
     expected_error: []const u8,
-) void {
+) *std.Build.Step.Compile {
     const tests = b.addTest(.{ .root_module = root_module });
     tests.expect_errors = .{ .contains = expected_error };
     compile_fail_step.dependOn(&tests.step);
+    return tests;
 }
 
 fn addZigPathCoverageGuard(b: *std.Build, lint_step: *std.Build.Step) void {
@@ -1054,7 +1055,12 @@ pub fn build(b: *std.Build) void {
     static_machine_step.dependOn(static_machine_wasm_step);
     check_step.dependOn(static_machine_wasm_step);
     const static_machine_parity_step = b.step("check-boundary-static-machine-parity", "Check Program.Session and StaticMachine semantic parity.");
-    static_machine_parity_step.dependOn(&run_static_machine_tests.step);
+    const static_machine_parity_tests = b.addTest(.{ .root_module = static_machine_tests_mod });
+    static_machine_parity_step.dependOn(&addRunArtifactWithArgs(
+        b,
+        static_machine_parity_tests,
+        proof_test_args.passthrough,
+    ).step);
     const static_agent_step = b.step("check-boundary-static-agent", "Check the StaticMachine agent fixture.");
     const static_agent_tests = b.addTest(.{
         .root_module = agent_loop_tests_mod,
@@ -1069,8 +1075,17 @@ pub fn build(b: *std.Build) void {
     static_provider_step.dependOn(&addRunArtifactWithArgs(b, static_provider_tests, test_args.passthrough).step);
 
     const compile_fail_step = b.step("compile-fail", "Check expected public ProgramPlan compile diagnostics.");
+    const static_machine_compile_fail = b.step(
+        "compile-fail-static-machine",
+        "Check expected Boundary StaticMachine compile diagnostics.",
+    );
     test_step.dependOn(compile_fail_step);
 
+    const release_metadata_mod = b.createModule(.{
+        .root_source_file = b.path("conformance/static-machine-v1/release_metadata.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
     const static_machine_release_mod = b.createModule(.{
         .root_source_file = b.path("conformance/static-machine-v1/release_test.zig"),
         .target = target,
@@ -1098,18 +1113,22 @@ pub fn build(b: *std.Build) void {
         readBuildFile(b, "docs/static_machine_compatibility.md"),
     );
     static_machine_release_mod.addImport("boundary", boundary);
+    static_machine_release_mod.addImport(
+        "boundary_static_machine_release_metadata",
+        release_metadata_mod,
+    );
     static_machine_release_mod.addOptions(
         "boundary_static_machine_release_sources",
         static_machine_release_sources,
     );
     const static_machine_release_tests = b.addTest(.{
         .root_module = static_machine_release_mod,
-        .filters = test_args.filters,
+        .filters = proof_test_args.filters,
     });
     const run_static_machine_release = addRunArtifactWithArgs(
         b,
         static_machine_release_tests,
-        test_args.passthrough,
+        proof_test_args.passthrough,
     );
     const static_machine_release_step = b.step(
         "check-boundary-static-machine-release",
@@ -1118,7 +1137,7 @@ pub fn build(b: *std.Build) void {
     static_machine_release_step.dependOn(&run_static_machine_release.step);
     static_machine_release_step.dependOn(static_machine_parity_step);
     static_machine_release_step.dependOn(static_machine_wasm_step);
-    static_machine_release_step.dependOn(compile_fail_step);
+    static_machine_release_step.dependOn(static_machine_compile_fail);
     check_step.dependOn(static_machine_release_step);
 
     const release_falsifier_tests = b.addTest(.{
@@ -1132,7 +1151,7 @@ pub fn build(b: *std.Build) void {
     release_falsifiers_step.dependOn(&addRunArtifactWithArgs(
         b,
         release_falsifier_tests,
-        test_args.passthrough,
+        proof_test_args.passthrough,
     ).step);
 
     const release_archive_check_mod = b.createModule(.{
@@ -1140,13 +1159,30 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    release_archive_check_mod.addImport(
+        "boundary_static_machine_release_metadata",
+        release_metadata_mod,
+    );
     const release_archive_checker = b.addExecutable(.{
         .name = "boundary-release-archive-check",
         .root_module = release_archive_check_mod,
     });
     const run_release_archive_checker = b.addRunArtifact(release_archive_checker);
     run_release_archive_checker.addArg(b.graph.zig_exe);
-    if (b.args) |args| run_release_archive_checker.addArgs(args);
+    const release_archive_path = b.option(
+        []const u8,
+        "boundary-release-archive",
+        "Path to the materialized Boundary v0.7.0 archive.",
+    );
+    if (release_archive_path) |archive_path| {
+        const archive_snapshot = b.addWriteFiles().addCopyFile(
+            .{ .cwd_relative = archive_path },
+            "boundary-v0.7.0.tar.gz",
+        );
+        run_release_archive_checker.addFileArg(archive_snapshot);
+    } else {
+        run_release_archive_checker.addArg("");
+    }
     const release_archive_step = b.step(
         "check-boundary-static-machine-release-archive",
         "Check a materialized Boundary v0.7.0 archive SHA-256 and Zig package hash.",
@@ -1164,7 +1200,7 @@ pub fn build(b: *std.Build) void {
     archive_falsifiers_step.dependOn(&addRunArtifactWithArgs(
         b,
         archive_falsifier_tests,
-        test_args.passthrough,
+        proof_test_args.passthrough,
     ).step);
 
     const evidence_kernel_tests_mod = b.createModule(.{
@@ -1686,7 +1722,15 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         });
         compile_fail_mod.addImport("boundary", boundary);
-        addCompileFailArtifact(b, compile_fail_step, compile_fail_mod, spec.expected_error);
+        const compile_fail_test = addCompileFailArtifact(
+            b,
+            compile_fail_step,
+            compile_fail_mod,
+            spec.expected_error,
+        );
+        if (std.mem.startsWith(u8, spec.path, "test/compile_fail/static_machine_")) {
+            static_machine_compile_fail.dependOn(&compile_fail_test.step);
+        }
     }
 
     const examples = [_]struct {

--- a/build.zig
+++ b/build.zig
@@ -1180,19 +1180,32 @@ pub fn build(b: *std.Build) void {
         "Path to the materialized Boundary v0.7.0 archive.",
     );
     if (release_archive_path) |archive_path| {
-        const archive_snapshot = b.addWriteFiles().addCopyFile(
-            .{ .cwd_relative = archive_path },
-            "boundary-v0.7.0.tar.gz",
-        );
-        run_release_archive_checker.addFileArg(archive_snapshot);
+        run_release_archive_checker.addArg(archive_path);
+        run_release_archive_checker.has_side_effects = true;
     } else {
         run_release_archive_checker.addArg("");
     }
+    const release_archive_once_step = b.step(
+        "check-boundary-static-machine-release-archive-once",
+        "Run one current-byte Boundary v0.7.0 materialized archive identity check.",
+    );
+    release_archive_once_step.dependOn(&run_release_archive_checker.step);
     const release_archive_step = b.step(
         "check-boundary-static-machine-release-archive",
         "Check a materialized Boundary v0.7.0 archive SHA-256 and Zig package hash.",
     );
-    release_archive_step.dependOn(&run_release_archive_checker.step);
+    release_archive_step.dependOn(release_archive_once_step);
+    if (release_archive_path) |archive_path| {
+        const archive_cache_falsifier = b.addSystemCommand(&.{"sh"});
+        archive_cache_falsifier.addFileArg(
+            b.path("conformance/static-machine-v1/release_archive_cache_falsifier.sh"),
+        );
+        archive_cache_falsifier.addArg(b.graph.zig_exe);
+        archive_cache_falsifier.addDirectoryArg(b.path("."));
+        archive_cache_falsifier.addArg(archive_path);
+        archive_cache_falsifier.has_side_effects = true;
+        release_archive_step.dependOn(&archive_cache_falsifier.step);
+    }
 
     const archive_falsifier_tests = b.addTest(.{
         .root_module = release_archive_check_mod,

--- a/build.zig
+++ b/build.zig
@@ -1066,12 +1066,16 @@ pub fn build(b: *std.Build) void {
     static_machine_step.dependOn(static_machine_wasm_step);
     check_step.dependOn(static_machine_wasm_step);
     const static_machine_parity_step = b.step("check-boundary-static-machine-parity", "Check Program.Session and StaticMachine semantic parity.");
-    const static_machine_parity_tests = b.addTest(.{ .root_module = static_machine_tests_mod });
-    static_machine_parity_step.dependOn(&addRunArtifactWithArgs(
-        b,
-        static_machine_parity_tests,
-        proof_test_args.passthrough,
-    ).step);
+    if (test_args.filters.len == 0 and test_args.passthrough.len == 0) {
+        static_machine_parity_step.dependOn(&run_static_machine_tests.step);
+    } else {
+        const static_machine_parity_tests = b.addTest(.{ .root_module = static_machine_tests_mod });
+        static_machine_parity_step.dependOn(&addRunArtifactWithArgs(
+            b,
+            static_machine_parity_tests,
+            proof_test_args.passthrough,
+        ).step);
+    }
     const static_agent_step = b.step("check-boundary-static-agent", "Check the StaticMachine agent fixture.");
     const static_agent_tests = b.addTest(.{
         .root_module = agent_loop_tests_mod,

--- a/build.zig
+++ b/build.zig
@@ -1068,6 +1068,9 @@ pub fn build(b: *std.Build) void {
     });
     static_provider_step.dependOn(&addRunArtifactWithArgs(b, static_provider_tests, test_args.passthrough).step);
 
+    const compile_fail_step = b.step("compile-fail", "Check expected public ProgramPlan compile diagnostics.");
+    test_step.dependOn(compile_fail_step);
+
     const static_machine_release_mod = b.createModule(.{
         .root_source_file = b.path("conformance/static-machine-v1/release_test.zig"),
         .target = target,
@@ -1115,6 +1118,7 @@ pub fn build(b: *std.Build) void {
     static_machine_release_step.dependOn(&run_static_machine_release.step);
     static_machine_release_step.dependOn(static_machine_parity_step);
     static_machine_release_step.dependOn(static_machine_wasm_step);
+    static_machine_release_step.dependOn(compile_fail_step);
     check_step.dependOn(static_machine_release_step);
 
     const release_falsifier_tests = b.addTest(.{
@@ -1128,6 +1132,38 @@ pub fn build(b: *std.Build) void {
     release_falsifiers_step.dependOn(&addRunArtifactWithArgs(
         b,
         release_falsifier_tests,
+        test_args.passthrough,
+    ).step);
+
+    const release_archive_check_mod = b.createModule(.{
+        .root_source_file = b.path("conformance/static-machine-v1/release_archive_check.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const release_archive_checker = b.addExecutable(.{
+        .name = "boundary-release-archive-check",
+        .root_module = release_archive_check_mod,
+    });
+    const run_release_archive_checker = b.addRunArtifact(release_archive_checker);
+    run_release_archive_checker.addArg(b.graph.zig_exe);
+    if (b.args) |args| run_release_archive_checker.addArgs(args);
+    const release_archive_step = b.step(
+        "check-boundary-static-machine-release-archive",
+        "Check a materialized Boundary v0.7.0 archive SHA-256 and Zig package hash.",
+    );
+    release_archive_step.dependOn(&run_release_archive_checker.step);
+
+    const archive_falsifier_tests = b.addTest(.{
+        .root_module = release_archive_check_mod,
+        .filters = &.{"release archive falsifiers"},
+    });
+    const archive_falsifiers_step = b.step(
+        "check-boundary-static-machine-release-archive-falsifiers",
+        "Check deliberate Boundary v0.7.0 materialized-archive identity falsifiers.",
+    );
+    archive_falsifiers_step.dependOn(&addRunArtifactWithArgs(
+        b,
+        archive_falsifier_tests,
         test_args.passthrough,
     ).step);
 
@@ -1158,8 +1194,6 @@ pub fn build(b: *std.Build) void {
     const public_optional_tests = b.addTest(.{ .root_module = public_optional_tests_mod, .filters = test_args.filters });
     test_step.dependOn(&addRunArtifactWithArgs(b, public_optional_tests, test_args.passthrough).step);
 
-    const compile_fail_step = b.step("compile-fail", "Check expected public ProgramPlan compile diagnostics.");
-    test_step.dependOn(compile_fail_step);
     const compile_fail_specs = [_]struct {
         path: []const u8,
         expected_error: []const u8,
@@ -1834,6 +1868,7 @@ pub fn build(b: *std.Build) void {
             b.path("examples"),
             b.path("test"),
             b.path("bench"),
+            b.path("conformance"),
         },
         .exclude = &.{},
     });

--- a/build.zig
+++ b/build.zig
@@ -1212,6 +1212,7 @@ pub fn build(b: *std.Build) void {
     }
     run_release_archive_checker.addArg(release_global_cache_path);
     run_release_archive_checker.addArg(release_proof_root);
+    run_release_archive_checker.addArg("");
     const release_archive_once_step = b.step(
         "check-boundary-static-machine-release-archive-once",
         "Run one current-byte Boundary v0.7.0 materialized archive identity check.",
@@ -1237,7 +1238,14 @@ pub fn build(b: *std.Build) void {
 
     const archive_falsifier_tests = b.addTest(.{
         .root_module = release_archive_check_mod,
-        .filters = &.{"release archive falsifiers"},
+        .filters = &.{"release archive"},
+    });
+    const release_process_group_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("conformance/static-machine-v1/release_process_group.zig"),
+            .target = b.graph.host,
+            .optimize = optimize,
+        }),
     });
     const archive_falsifiers_step = b.step(
         "check-boundary-static-machine-release-archive-falsifiers",
@@ -1246,6 +1254,11 @@ pub fn build(b: *std.Build) void {
     archive_falsifiers_step.dependOn(&addRunArtifactWithArgs(
         b,
         archive_falsifier_tests,
+        proof_test_args.passthrough,
+    ).step);
+    archive_falsifiers_step.dependOn(&addRunArtifactWithArgs(
+        b,
+        release_process_group_tests,
         proof_test_args.passthrough,
     ).step);
 

--- a/build.zig
+++ b/build.zig
@@ -24,6 +24,18 @@ const TestArgs = struct {
     passthrough: []const []const u8,
 };
 
+fn readBuildFile(b: *std.Build, path: []const u8) []const u8 {
+    return std.Io.Dir.cwd().readFileAlloc(
+        std.Io.Threaded.global_single_threaded.io(),
+        b.pathFromRoot(path),
+        b.allocator,
+        .limited(1024 * 1024),
+    ) catch |err| std.process.fatal("unable to read release input '{s}': {s}", .{
+        path,
+        @errorName(err),
+    });
+}
+
 fn parseTestArgs(b: *std.Build) TestArgs {
     const args = b.args orelse return .{
         .filters = &.{},
@@ -1055,6 +1067,69 @@ pub fn build(b: *std.Build) void {
         .filters = &.{"agent StaticMachine toolbox provider"},
     });
     static_provider_step.dependOn(&addRunArtifactWithArgs(b, static_provider_tests, test_args.passthrough).step);
+
+    const static_machine_release_mod = b.createModule(.{
+        .root_source_file = b.path("conformance/static-machine-v1/release_test.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const static_machine_release_sources = b.addOptions();
+    static_machine_release_sources.addOption(
+        []const u8,
+        "readme_bytes",
+        readBuildFile(b, "README.md"),
+    );
+    static_machine_release_sources.addOption(
+        []const u8,
+        "release_hardening_bytes",
+        readBuildFile(b, "docs/release_hardening.md"),
+    );
+    static_machine_release_sources.addOption(
+        []const u8,
+        "static_machine_bytes",
+        readBuildFile(b, "docs/static_machine.md"),
+    );
+    static_machine_release_sources.addOption(
+        []const u8,
+        "compatibility_bytes",
+        readBuildFile(b, "docs/static_machine_compatibility.md"),
+    );
+    static_machine_release_mod.addImport("boundary", boundary);
+    static_machine_release_mod.addOptions(
+        "boundary_static_machine_release_sources",
+        static_machine_release_sources,
+    );
+    const static_machine_release_tests = b.addTest(.{
+        .root_module = static_machine_release_mod,
+        .filters = test_args.filters,
+    });
+    const run_static_machine_release = addRunArtifactWithArgs(
+        b,
+        static_machine_release_tests,
+        test_args.passthrough,
+    );
+    const static_machine_release_step = b.step(
+        "check-boundary-static-machine-release",
+        "Check the Boundary v0.7.0 identity, public StaticMachine ABI, and compatibility matrix.",
+    );
+    static_machine_release_step.dependOn(&run_static_machine_release.step);
+    static_machine_release_step.dependOn(static_machine_parity_step);
+    static_machine_release_step.dependOn(static_machine_wasm_step);
+    check_step.dependOn(static_machine_release_step);
+
+    const release_falsifier_tests = b.addTest(.{
+        .root_module = static_machine_release_mod,
+        .filters = &.{"release metadata falsifiers"},
+    });
+    const release_falsifiers_step = b.step(
+        "check-boundary-static-machine-release-falsifiers",
+        "Check deliberate Boundary v0.7.0 identity and compatibility-matrix falsifiers.",
+    );
+    release_falsifiers_step.dependOn(&addRunArtifactWithArgs(
+        b,
+        release_falsifier_tests,
+        test_args.passthrough,
+    ).step);
 
     const evidence_kernel_tests_mod = b.createModule(.{
         .root_source_file = b.path("test/evidence_kernel_test.zig"),

--- a/build.zig
+++ b/build.zig
@@ -36,6 +36,17 @@ fn readBuildFile(b: *std.Build, path: []const u8) []const u8 {
     });
 }
 
+fn absoluteBuildDirectoryPath(
+    b: *std.Build,
+    directory: std.Build.Cache.Directory,
+    label: []const u8,
+) []const u8 {
+    var buffer: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const length = directory.handle.realPath(b.graph.io, &buffer) catch |err|
+        std.process.fatal("unable to resolve {s}: {s}", .{ label, @errorName(err) });
+    return b.dupe(buffer[0..length]);
+}
+
 fn parseTestArgs(b: *std.Build) TestArgs {
     const args = b.args orelse return .{
         .filters = &.{},
@@ -1174,13 +1185,16 @@ pub fn build(b: *std.Build) void {
     });
     const run_release_archive_checker = b.addRunArtifact(release_archive_checker);
     run_release_archive_checker.addArg(b.graph.zig_exe);
-    const configured_global_cache_path = b.graph.global_cache_root.path orelse ".";
-    const release_global_cache_path = if (std.Io.Dir.path.isAbsolute(
-        configured_global_cache_path,
-    ))
-        configured_global_cache_path
-    else
-        b.pathFromRoot(configured_global_cache_path);
+    const release_global_cache_path = absoluteBuildDirectoryPath(
+        b,
+        b.graph.global_cache_root,
+        "Zig global cache root",
+    );
+    const release_proof_root = absoluteBuildDirectoryPath(
+        b,
+        b.cache_root,
+        "Boundary release proof root",
+    );
     const release_archive_path = b.option(
         []const u8,
         "boundary-release-archive",
@@ -1193,6 +1207,7 @@ pub fn build(b: *std.Build) void {
         run_release_archive_checker.addArg("");
     }
     run_release_archive_checker.addArg(release_global_cache_path);
+    run_release_archive_checker.addArg(release_proof_root);
     const release_archive_once_step = b.step(
         "check-boundary-static-machine-release-archive-once",
         "Run one current-byte Boundary v0.7.0 materialized archive identity check.",

--- a/build.zig
+++ b/build.zig
@@ -1086,6 +1086,11 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const release_archive_metadata_mod = b.createModule(.{
+        .root_source_file = b.path("conformance/static-machine-v1/release_metadata.zig"),
+        .target = b.graph.host,
+        .optimize = optimize,
+    });
     const static_machine_release_mod = b.createModule(.{
         .root_source_file = b.path("conformance/static-machine-v1/release_test.zig"),
         .target = target,
@@ -1156,12 +1161,12 @@ pub fn build(b: *std.Build) void {
 
     const release_archive_check_mod = b.createModule(.{
         .root_source_file = b.path("conformance/static-machine-v1/release_archive_check.zig"),
-        .target = target,
+        .target = b.graph.host,
         .optimize = optimize,
     });
     release_archive_check_mod.addImport(
         "boundary_static_machine_release_metadata",
-        release_metadata_mod,
+        release_archive_metadata_mod,
     );
     const release_archive_checker = b.addExecutable(.{
         .name = "boundary-release-archive-check",

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "docs/release_hardening.md",
-        "sha256": "94ac68a1faa6b250771a92923853a09afdbbc97c4feed54660f560401fcbecf9"
+        "sha256": "1a9bf0961d85251720d80439805badab78c5bc02c7d464a64f714f46b901a81d"
       },
       {
         "path": "docs/static_machine.md",

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -10,7 +10,7 @@
   },
   "documentation_supplement": {
     "included_in_code_archive": false,
-    "identity_kind": "ordered-sha256-file-set-v1",
+    "identity_kind": "ordered-canonical-text-sha256-file-set-v1",
     "publication_binding": "reviewed-release-closure-git-commit",
     "files": [
       {
@@ -19,7 +19,7 @@
       },
       {
         "path": "docs/release_hardening.md",
-        "sha256": "63da5ea86e21526ebb8cfcd55b8e7802f67ae5a548b47e2de8500582ede8b883"
+        "sha256": "94ac68a1faa6b250771a92923853a09afdbbc97c4feed54660f560401fcbecf9"
       },
       {
         "path": "docs/static_machine.md",

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -18,7 +18,7 @@
       },
       {
         "path": "docs/release_hardening.md",
-        "sha256": "6c9dcd673995a1fa2f87d8b63c627001b7ea1499f1c7d2925ead7a897b8f76e1"
+        "sha256": "6cd33b5739fcb4e04cd0ef7306196a5913f7826c74ce0b67b8fd62a835eb55b9"
       },
       {
         "path": "docs/static_machine.md",
@@ -26,7 +26,7 @@
       },
       {
         "path": "docs/static_machine_compatibility.md",
-        "sha256": "19d2032e6ea4e095a16a443049478b0c8f33c7ce3c04ee3623d487dd45fb777b"
+        "sha256": "f98ab80e017c9fb7f4fd1ced1c2fb0a5764b69d0a12910efa036907a703fd0d8"
       }
     ]
   },

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -27,7 +27,7 @@
       },
       {
         "path": "docs/static_machine_compatibility.md",
-        "sha256": "7b9ba666f6eeee4845d674a5a083c5d1a434be61e640d1cc65a0802d4a8fab13"
+        "sha256": "918e1d85936eee1f4a8c781d5b9fd5a311250cf8da52eb79ff411ef3f23fa645"
       }
     ]
   },

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -1,0 +1,62 @@
+{
+  "schema": "boundary-static-machine-release/v1",
+  "code_archive": {
+    "tag": "v0.7.0",
+    "commit": "7f2472100454aa2cd5c62e07db0c1e23eaf46a77",
+    "url": "https://github.com/tkersey/boundary/archive/refs/tags/v0.7.0.tar.gz",
+    "sha256": "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a",
+    "zig_package_hash": "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_"
+  },
+  "documentation_supplement": {
+    "included_in_code_archive": false,
+    "identity_kind": "ordered-sha256-file-set-v1",
+    "publication_binding": "reviewed-release-closure-git-commit",
+    "files": [
+      {
+        "path": "README.md",
+        "sha256": "7a05067edd16af87616f68d6ffae87e7baf623c6e7153185d43f805c9f52aab8"
+      },
+      {
+        "path": "docs/release_hardening.md",
+        "sha256": "6c9dcd673995a1fa2f87d8b63c627001b7ea1499f1c7d2925ead7a897b8f76e1"
+      },
+      {
+        "path": "docs/static_machine.md",
+        "sha256": "9c2e624621216bf45ab6972d7608a5c2aec8fe9adfda4a1bd07d2e32928b86ad"
+      },
+      {
+        "path": "docs/static_machine_compatibility.md",
+        "sha256": "19d2032e6ea4e095a16a443049478b0c8f33c7ce3c04ee3623d487dd45fb777b"
+      }
+    ]
+  },
+  "static_machine_abi": {
+    "version": 1,
+    "constructor": "boundary.staticMachine",
+    "options": "boundary.StaticMachineOptions",
+    "state_encoding": "canonical_v1",
+    "world_ports": "explicit",
+    "compatibility_document": "docs/static_machine_compatibility.md",
+    "supported_contracts": [
+      "authentic-boundary-program",
+      "canonical-v1-state",
+      "explicit-world-ports",
+      "acyclic-static-helper-provider-graphs",
+      "admitted-scalar-product-sum-carriers",
+      "closed-authored-failure-set",
+      "bounded-frames-state-and-validation-work",
+      "native-and-wasm32-freestanding"
+    ],
+    "unsupported_contracts": [
+      "recursive-helper-provider-graphs",
+      "program-output-or-cleanup-hooks",
+      "mutable-string-list-carriers",
+      "comptime-struct-fields",
+      "non-exhaustive-enums",
+      "unrepresentable-compact-condition-histories",
+      "dynamic-provider-discovery",
+      "runtime-module-loading",
+      "v0-continuation-migration"
+    ]
+  }
+}

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "docs/release_hardening.md",
-        "sha256": "1a9bf0961d85251720d80439805badab78c5bc02c7d464a64f714f46b901a81d"
+        "sha256": "258e8304ebc0178edd80bc569e1c86e77fb97bdca2b84b82c5358a6dab021254"
       },
       {
         "path": "docs/static_machine.md",

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -19,7 +19,7 @@
       },
       {
         "path": "docs/release_hardening.md",
-        "sha256": "258e8304ebc0178edd80bc569e1c86e77fb97bdca2b84b82c5358a6dab021254"
+        "sha256": "f03799d6b5bba64b578eaa736de3d98beb77c712418cd4c26ef1d9c5e816f7ed"
       },
       {
         "path": "docs/static_machine.md",

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -5,7 +5,8 @@
     "commit": "7f2472100454aa2cd5c62e07db0c1e23eaf46a77",
     "url": "https://github.com/tkersey/boundary/archive/refs/tags/v0.7.0.tar.gz",
     "sha256": "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a",
-    "zig_package_hash": "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_"
+    "zig_package_hash": "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_",
+    "zig_version": "0.16.0"
   },
   "documentation_supplement": {
     "included_in_code_archive": false,
@@ -18,7 +19,7 @@
       },
       {
         "path": "docs/release_hardening.md",
-        "sha256": "6cd33b5739fcb4e04cd0ef7306196a5913f7826c74ce0b67b8fd62a835eb55b9"
+        "sha256": "63da5ea86e21526ebb8cfcd55b8e7802f67ae5a548b47e2de8500582ede8b883"
       },
       {
         "path": "docs/static_machine.md",
@@ -26,7 +27,7 @@
       },
       {
         "path": "docs/static_machine_compatibility.md",
-        "sha256": "f98ab80e017c9fb7f4fd1ced1c2fb0a5764b69d0a12910efa036907a703fd0d8"
+        "sha256": "7b9ba666f6eeee4845d674a5a083c5d1a434be61e640d1cc65a0802d4a8fab13"
       }
     ]
   },

--- a/conformance/static-machine-v1/release-metadata.json
+++ b/conformance/static-machine-v1/release-metadata.json
@@ -15,7 +15,7 @@
     "files": [
       {
         "path": "README.md",
-        "sha256": "7a05067edd16af87616f68d6ffae87e7baf623c6e7153185d43f805c9f52aab8"
+        "sha256": "849fdd51cc1f3d1c79df59bdc122f41337868d4353d02108f22f0c3db585f93d"
       },
       {
         "path": "docs/release_hardening.md",

--- a/conformance/static-machine-v1/release_archive_cache_falsifier.sh
+++ b/conformance/static-machine-v1/release_archive_cache_falsifier.sh
@@ -17,27 +17,53 @@ esac
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-cache.XXXXXX")
 proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
 child_pid=
+cleanup_allowed=yes
 
 cleanup() {
+    if [ "$cleanup_allowed" != yes ]; then
+        printf 'retaining proof root after incomplete process-group shutdown: %s\n' \
+            "$proof_root" >&2
+        return
+    fi
     case "$proof_root" in
         */boundary-release-archive-cache.*) rm -rf "$proof_root" ;;
         *) printf 'refusing to remove unexpected proof root: %s\n' "$proof_root" >&2 ;;
     esac
 }
+terminate_child() {
+    if [ -n "$child_pid" ]; then
+        terminating_pid=$child_pid
+        # Direct-first covers pre-setpgid cancellation; group-second closes
+        # the spawn race after the helper owns its process group.
+        kill -TERM "$terminating_pid" 2>/dev/null || :
+        kill -TERM -"$terminating_pid" 2>/dev/null || :
+        wait "$child_pid" 2>/dev/null || :
+        shutdown_attempt=0
+        while kill -0 -"$terminating_pid" 2>/dev/null; do
+            shutdown_attempt=$((shutdown_attempt + 1))
+            if [ "$shutdown_attempt" -eq 4 ]; then
+                kill -KILL -"$terminating_pid" 2>/dev/null || :
+            fi
+            if [ "$shutdown_attempt" -ge 8 ]; then
+                cleanup_allowed=no
+                child_pid=
+                return 1
+            fi
+            sleep 1
+        done
+        child_pid=
+    fi
+}
 on_signal() {
     signal_status=$1
-    if [ -n "$child_pid" ]; then
-        kill -TERM "$child_pid" 2>/dev/null || :
-        wait "$child_pid" 2>/dev/null || :
-    fi
+    terminate_child || :
     exit "$signal_status"
 }
 trap cleanup EXIT
 trap 'on_signal 129' HUP
 trap 'on_signal 130' INT
 trap 'on_signal 143' TERM
-trap >"$proof_root/trap-state"
-if ! grep -Fq 'on_signal 130' "$proof_root/trap-state"; then
+if ! sh -c 'trap "exit 0" INT; kill -INT "$$"; exit 1'; then
     printf '%s\n' 'release archive check signal handler unavailable: INT' >&2
     exit 2
 fi
@@ -46,17 +72,54 @@ proof_archive="$proof_root/boundary-v0.7.0.tar.gz"
 mtime_reference="$proof_root/mtime-reference.tar.gz"
 proof_output="$proof_root/rejected-output.txt"
 local_cache="$proof_root/local-cache"
+process_group_exe="$proof_root/boundary-release-process-group"
+process_group_ready="$proof_root/process-group-ready"
+mkdir -p "$local_cache"
+
+"$zig_exe" build-exe \
+    --cache-dir "$local_cache" \
+    --global-cache-dir "$global_cache" \
+    -OReleaseSafe \
+    -femit-bin="$process_group_exe" \
+    "$repository_root/conformance/static-machine-v1/release_process_group.zig" &
+child_pid=$!
+if wait "$child_pid"; then
+    child_status=0
+else
+    child_status=$?
+fi
+child_pid=
+if [ "$child_status" -ne 0 ] || [ ! -x "$process_group_exe" ]; then
+    printf '%s\n' 'archive cache falsifier process-group helper build failed' >&2
+    exit 2
+fi
 
 run_build() {
-    (
-        cd "$repository_root"
-        exec "$zig_exe" build \
-            --cache-dir "$local_cache" \
-            --global-cache-dir "$global_cache" \
-            check-boundary-static-machine-release-archive-once \
-            -Dboundary-release-archive="$proof_archive"
-    ) &
+    rm -f "$process_group_ready"
+    "$process_group_exe" \
+        "$process_group_ready" \
+        "$zig_exe" build \
+        --build-file "$repository_root/build.zig" \
+        --cache-dir "$local_cache" \
+        --global-cache-dir "$global_cache" \
+        check-boundary-static-machine-release-archive-once \
+        -Dboundary-release-archive="$proof_archive" &
     child_pid=$!
+    while [ ! -f "$process_group_ready" ]; do
+        if ! kill -0 "$child_pid" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+    ready_line=
+    if [ -f "$process_group_ready" ]; then
+        IFS= read -r ready_line <"$process_group_ready" || :
+    fi
+    if [ "$ready_line" != "boundary-release-process-group/v1 $child_pid" ]; then
+        terminate_child || :
+        printf '%s\n' 'archive cache falsifier process-group helper did not become ready' >&2
+        return 2
+    fi
     if wait "$child_pid"; then
         child_status=0
     else

--- a/conformance/static-machine-v1/release_archive_cache_falsifier.sh
+++ b/conformance/static-machine-v1/release_archive_cache_falsifier.sh
@@ -12,6 +12,7 @@ repository_root=$2
 reviewed_archive=$3
 global_cache=$4
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-cache.XXXXXX")
+proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
 
 cleanup() {
     case "$proof_root" in

--- a/conformance/static-machine-v1/release_archive_cache_falsifier.sh
+++ b/conformance/static-machine-v1/release_archive_cache_falsifier.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
 set -eu
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -ne 4 ]; then
     printf '%s\n' \
-        'usage: release_archive_cache_falsifier.sh <zig-exe> <repository-root> <reviewed-archive>' >&2
+        'usage: release_archive_cache_falsifier.sh <zig-exe> <repository-root> <reviewed-archive> <global-cache>' >&2
     exit 2
 fi
 
 zig_exe=$1
 repository_root=$2
 reviewed_archive=$3
+global_cache=$4
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-cache.XXXXXX")
 
 cleanup() {
@@ -26,6 +27,7 @@ proof_output="$proof_root/rejected-output.txt"
 local_cache="$proof_root/local-cache"
 
 cp "$reviewed_archive" "$proof_archive"
+chmod u+w "$proof_archive"
 touch -t 202001010000 "$proof_archive"
 cp -p "$proof_archive" "$mtime_reference"
 
@@ -33,6 +35,7 @@ cp -p "$proof_archive" "$mtime_reference"
     cd "$repository_root"
     "$zig_exe" build \
         --cache-dir "$local_cache" \
+        --global-cache-dir "$global_cache" \
         check-boundary-static-machine-release-archive-once \
         -Dboundary-release-archive="$proof_archive"
 )
@@ -44,6 +47,7 @@ if (
     cd "$repository_root"
     "$zig_exe" build \
         --cache-dir "$local_cache" \
+        --global-cache-dir "$global_cache" \
         check-boundary-static-machine-release-archive-once \
         -Dboundary-release-archive="$proof_archive"
 ) >"$proof_output" 2>&1; then

--- a/conformance/static-machine-v1/release_archive_cache_falsifier.sh
+++ b/conformance/static-machine-v1/release_archive_cache_falsifier.sh
@@ -11,6 +11,9 @@ zig_exe=$1
 repository_root=$2
 reviewed_archive=$3
 global_cache=$4
+case "$reviewed_archive" in
+    -*) reviewed_archive="./$reviewed_archive" ;;
+esac
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-cache.XXXXXX")
 proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
 
@@ -20,7 +23,13 @@ cleanup() {
         *) printf 'refusing to remove unexpected proof root: %s\n' "$proof_root" >&2 ;;
     esac
 }
-trap cleanup EXIT HUP INT TERM
+on_signal() {
+    exit "$1"
+}
+trap cleanup EXIT
+trap 'on_signal 129' HUP
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
 
 proof_archive="$proof_root/boundary-v0.7.0.tar.gz"
 mtime_reference="$proof_root/mtime-reference.tar.gz"

--- a/conformance/static-machine-v1/release_archive_cache_falsifier.sh
+++ b/conformance/static-machine-v1/release_archive_cache_falsifier.sh
@@ -16,6 +16,7 @@ case "$reviewed_archive" in
 esac
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-cache.XXXXXX")
 proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
+child_pid=
 
 cleanup() {
     case "$proof_root" in
@@ -24,43 +25,58 @@ cleanup() {
     esac
 }
 on_signal() {
-    exit "$1"
+    signal_status=$1
+    if [ -n "$child_pid" ]; then
+        kill -TERM "$child_pid" 2>/dev/null || :
+        wait "$child_pid" 2>/dev/null || :
+    fi
+    exit "$signal_status"
 }
 trap cleanup EXIT
 trap 'on_signal 129' HUP
 trap 'on_signal 130' INT
 trap 'on_signal 143' TERM
+trap >"$proof_root/trap-state"
+if ! grep -Fq 'on_signal 130' "$proof_root/trap-state"; then
+    printf '%s\n' 'release archive check signal handler unavailable: INT' >&2
+    exit 2
+fi
 
 proof_archive="$proof_root/boundary-v0.7.0.tar.gz"
 mtime_reference="$proof_root/mtime-reference.tar.gz"
 proof_output="$proof_root/rejected-output.txt"
 local_cache="$proof_root/local-cache"
 
+run_build() {
+    (
+        cd "$repository_root"
+        exec "$zig_exe" build \
+            --cache-dir "$local_cache" \
+            --global-cache-dir "$global_cache" \
+            check-boundary-static-machine-release-archive-once \
+            -Dboundary-release-archive="$proof_archive"
+    ) &
+    child_pid=$!
+    if wait "$child_pid"; then
+        child_status=0
+    else
+        child_status=$?
+    fi
+    child_pid=
+    return "$child_status"
+}
+
 cp "$reviewed_archive" "$proof_archive"
 chmod u+w "$proof_archive"
 touch -t 202001010000 "$proof_archive"
 cp -p "$proof_archive" "$mtime_reference"
 
-(
-    cd "$repository_root"
-    "$zig_exe" build \
-        --cache-dir "$local_cache" \
-        --global-cache-dir "$global_cache" \
-        check-boundary-static-machine-release-archive-once \
-        -Dboundary-release-archive="$proof_archive"
-)
+run_build
 
 printf 'X' | dd of="$proof_archive" bs=1 count=1 conv=notrunc 2>/dev/null
 touch -r "$mtime_reference" "$proof_archive"
 
-if (
-    cd "$repository_root"
-    "$zig_exe" build \
-        --cache-dir "$local_cache" \
-        --global-cache-dir "$global_cache" \
-        check-boundary-static-machine-release-archive-once \
-        -Dboundary-release-archive="$proof_archive"
-) >"$proof_output" 2>&1; then
+if run_build >"$proof_output" 2>&1; then
     printf '%s\n' \
         'archive cache falsifier failed: substituted current bytes were accepted' >&2
     exit 1

--- a/conformance/static-machine-v1/release_archive_cache_falsifier.sh
+++ b/conformance/static-machine-v1/release_archive_cache_falsifier.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+    printf '%s\n' \
+        'usage: release_archive_cache_falsifier.sh <zig-exe> <repository-root> <reviewed-archive>' >&2
+    exit 2
+fi
+
+zig_exe=$1
+repository_root=$2
+reviewed_archive=$3
+proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-cache.XXXXXX")
+
+cleanup() {
+    case "$proof_root" in
+        */boundary-release-archive-cache.*) rm -rf "$proof_root" ;;
+        *) printf 'refusing to remove unexpected proof root: %s\n' "$proof_root" >&2 ;;
+    esac
+}
+trap cleanup EXIT HUP INT TERM
+
+proof_archive="$proof_root/boundary-v0.7.0.tar.gz"
+mtime_reference="$proof_root/mtime-reference.tar.gz"
+proof_output="$proof_root/rejected-output.txt"
+local_cache="$proof_root/local-cache"
+
+cp "$reviewed_archive" "$proof_archive"
+touch -t 202001010000 "$proof_archive"
+cp -p "$proof_archive" "$mtime_reference"
+
+(
+    cd "$repository_root"
+    "$zig_exe" build \
+        --cache-dir "$local_cache" \
+        check-boundary-static-machine-release-archive-once \
+        -Dboundary-release-archive="$proof_archive"
+)
+
+printf 'X' | dd of="$proof_archive" bs=1 count=1 conv=notrunc 2>/dev/null
+touch -r "$mtime_reference" "$proof_archive"
+
+if (
+    cd "$repository_root"
+    "$zig_exe" build \
+        --cache-dir "$local_cache" \
+        check-boundary-static-machine-release-archive-once \
+        -Dboundary-release-archive="$proof_archive"
+) >"$proof_output" 2>&1; then
+    printf '%s\n' \
+        'archive cache falsifier failed: substituted current bytes were accepted' >&2
+    exit 1
+fi
+
+if ! grep -Fq 'archive SHA-256 mismatch' "$proof_output"; then
+    printf '%s\n' \
+        'archive cache falsifier failed without the expected current-byte rejection' >&2
+    sed -n '1,160p' "$proof_output" >&2
+    exit 1
+fi

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -3,6 +3,8 @@ const release_metadata = @import("boundary_static_machine_release_metadata");
 const std = @import("std");
 
 const maximum_archive_bytes = 32 * 1024 * 1024;
+const completion_receipt_name = "archive-check-complete";
+const completion_receipt_bytes = "boundary-release-archive-check/v1\n";
 
 const VerificationError = error{
     ArchiveSha256Mismatch,
@@ -231,13 +233,37 @@ fn verifyArchive(
     };
 }
 
+fn writeCompletionReceipt(
+    init: std.process.Init,
+    proof_root: []const u8,
+    receipt_path: []const u8,
+) !void {
+    if (receipt_path.len == 0) return;
+    const expected_path = try std.Io.Dir.path.join(
+        init.gpa,
+        &.{ proof_root, completion_receipt_name },
+    );
+    defer init.gpa.free(expected_path);
+    if (!std.Io.Dir.path.isAbsolute(receipt_path) or
+        !std.mem.eql(u8, receipt_path, expected_path))
+    {
+        return error.InvalidCompletionReceiptPath;
+    }
+    var receipt = try std.Io.Dir.createFileAbsolute(init.io, receipt_path, .{
+        .exclusive = true,
+        .permissions = @enumFromInt(0o600),
+    });
+    defer receipt.close(init.io);
+    try receipt.writeStreamingAll(init.io, completion_receipt_bytes);
+}
+
 /// Verifies one local Boundary v0.7.0 archive against both reviewed identities.
 pub fn main(init: std.process.Init) anyerror!void {
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.next();
     const zig_exe = args.next() orelse {
         std.log.err(
-            "usage: boundary-release-archive-check <zig-exe> <archive-path> <global-cache-path> <proof-root>",
+            "usage: boundary-release-archive-check <zig-exe> <archive-path> <global-cache-path> <proof-root> <completion-receipt-path-or-empty>",
             .{},
         );
         return error.InvalidArguments;
@@ -275,6 +301,10 @@ pub fn main(init: std.process.Init) anyerror!void {
         std.log.err("proof root must be an absolute writable directory", .{});
         return error.InvalidArguments;
     }
+    const completion_receipt_path = args.next() orelse {
+        std.log.err("missing completion receipt path; pass an empty value only for build-integrated verification", .{});
+        return error.InvalidArguments;
+    };
     if (args.next() != null) return error.InvalidArguments;
     try verifyArchive(
         init,
@@ -283,6 +313,7 @@ pub fn main(init: std.process.Init) anyerror!void {
         global_cache_path,
         proof_root,
     );
+    try writeCompletionReceipt(init, proof_root, completion_receipt_path);
 }
 
 test "release archive falsifiers retain wrong byte and command identities" {
@@ -336,5 +367,16 @@ test "release archive falsifiers retain wrong byte and command identities" {
             expected.zig_version,
             error.ZigVersionMismatch,
         ),
+    );
+}
+
+test "release archive completion receipt is canonical" {
+    try std.testing.expectEqualStrings(
+        "archive-check-complete",
+        completion_receipt_name,
+    );
+    try std.testing.expectEqualStrings(
+        "boundary-release-archive-check/v1\n",
+        completion_receipt_bytes,
     );
 }

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -1,0 +1,89 @@
+// zlinter-disable require_errdefer_dealloc
+const std = @import("std");
+
+const expected_archive_sha256 = "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a";
+const expected_package_hash = "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_";
+const maximum_archive_bytes = 32 * 1024 * 1024;
+
+const VerificationError = error{
+    ArchiveSha256Mismatch,
+    PackageHashMismatch,
+    ZigFetchFailed,
+};
+
+fn archiveSha256(bytes: []const u8) [64]u8 {
+    var digest: [32]u8 = @splat(0);
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    return std.fmt.bytesToHex(digest, .lower);
+}
+
+fn verifyArchiveSha256(bytes: []const u8, expected: []const u8) VerificationError!void {
+    const actual = archiveSha256(bytes);
+    if (!std.mem.eql(u8, &actual, expected)) return error.ArchiveSha256Mismatch;
+}
+
+fn verifyPackageHash(output: []const u8, expected: []const u8) VerificationError!void {
+    const actual = std.mem.trim(u8, output, " \r\n\t");
+    if (!std.mem.eql(u8, actual, expected)) return error.PackageHashMismatch;
+}
+
+fn verifyArchive(
+    init: std.process.Init,
+    zig_exe: []const u8,
+    archive_path: []const u8,
+) !void {
+    const archive_bytes = try std.Io.Dir.cwd().readFileAlloc(
+        init.io,
+        archive_path,
+        init.gpa,
+        .limited(maximum_archive_bytes),
+    );
+    defer init.gpa.free(archive_bytes);
+    try verifyArchiveSha256(archive_bytes, expected_archive_sha256);
+
+    const result = try std.process.run(init.gpa, init.io, .{
+        .argv = &.{ zig_exe, "fetch", archive_path },
+        .stdout_limit = .limited(1024),
+        .stderr_limit = .limited(16 * 1024),
+    });
+    defer init.gpa.free(result.stdout);
+    defer init.gpa.free(result.stderr);
+    switch (result.term) {
+        .exited => |code| if (code != 0) {
+            std.log.err("zig fetch failed for '{s}': {s}", .{ archive_path, result.stderr });
+            return error.ZigFetchFailed;
+        },
+        else => {
+            std.log.err("zig fetch terminated abnormally for '{s}'", .{archive_path});
+            return error.ZigFetchFailed;
+        },
+    }
+    try verifyPackageHash(result.stdout, expected_package_hash);
+}
+
+/// Verifies one local Boundary v0.7.0 archive against both reviewed identities.
+pub fn main(init: std.process.Init) anyerror!void {
+    var args = std.process.Args.Iterator.init(init.minimal.args);
+    _ = args.next();
+    const zig_exe = args.next() orelse {
+        std.log.err("usage: boundary-release-archive-check <zig-exe> <archive-path>", .{});
+        return error.InvalidArguments;
+    };
+    const archive_path = args.next() orelse {
+        std.log.err("usage: boundary-release-archive-check <zig-exe> <archive-path>", .{});
+        return error.InvalidArguments;
+    };
+    if (args.next() != null) return error.InvalidArguments;
+    try verifyArchive(init, zig_exe, archive_path);
+}
+
+test "release archive falsifiers reject wrong byte and package identities" {
+    try std.testing.expectError(
+        error.ArchiveSha256Mismatch,
+        verifyArchiveSha256("not the reviewed archive", expected_archive_sha256),
+    );
+    try std.testing.expectError(
+        error.PackageHashMismatch,
+        verifyPackageHash("boundary-floating-branch\n", expected_package_hash),
+    );
+}

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -1,14 +1,20 @@
 // zlinter-disable require_errdefer_dealloc
+const release_metadata = @import("boundary_static_machine_release_metadata");
 const std = @import("std");
 
-const expected_archive_sha256 = "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a";
-const expected_package_hash = "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_";
 const maximum_archive_bytes = 32 * 1024 * 1024;
 
 const VerificationError = error{
+    ArchiveSnapshotChanged,
     ArchiveSha256Mismatch,
     PackageHashMismatch,
+    ZigVersionMismatch,
     ZigFetchFailed,
+};
+
+const ArchiveSha256Comparison = struct {
+    actual: [64]u8,
+    matches: bool,
 };
 
 fn archiveSha256(bytes: []const u8) [64]u8 {
@@ -17,14 +23,48 @@ fn archiveSha256(bytes: []const u8) [64]u8 {
     return std.fmt.bytesToHex(digest, .lower);
 }
 
-fn verifyArchiveSha256(bytes: []const u8, expected: []const u8) VerificationError!void {
+fn compareArchiveSha256(bytes: []const u8, expected: []const u8) ArchiveSha256Comparison {
     const actual = archiveSha256(bytes);
-    if (!std.mem.eql(u8, &actual, expected)) return error.ArchiveSha256Mismatch;
+    return .{
+        .actual = actual,
+        .matches = std.mem.eql(u8, &actual, expected),
+    };
 }
 
-fn verifyPackageHash(output: []const u8, expected: []const u8) VerificationError!void {
-    const actual = std.mem.trim(u8, output, " \r\n\t");
-    if (!std.mem.eql(u8, actual, expected)) return error.PackageHashMismatch;
+fn verifyArchiveSha256(bytes: []const u8, expected: []const u8) VerificationError!void {
+    if (!compareArchiveSha256(bytes, expected).matches) {
+        return error.ArchiveSha256Mismatch;
+    }
+}
+
+fn verifyCommandOutput(
+    output: []const u8,
+    expected: []const u8,
+    comptime mismatch: VerificationError,
+) VerificationError!void {
+    if (!std.mem.eql(u8, std.mem.trim(u8, output, " \r\n\t"), expected)) {
+        return mismatch;
+    }
+}
+
+fn runZig(
+    init: std.process.Init,
+    argv: []const []const u8,
+    failure_label: []const u8,
+) !std.process.RunResult {
+    const result = try std.process.run(init.gpa, init.io, .{
+        .argv = argv,
+        .stdout_limit = .limited(1024),
+        .stderr_limit = .limited(16 * 1024),
+    });
+    switch (result.term) {
+        .exited => |code| if (code == 0) return result,
+        else => {},
+    }
+    std.log.err("{s} failed: {s}", .{ failure_label, result.stderr });
+    init.gpa.free(result.stdout);
+    init.gpa.free(result.stderr);
+    return error.ZigFetchFailed;
 }
 
 fn verifyArchive(
@@ -32,6 +72,25 @@ fn verifyArchive(
     zig_exe: []const u8,
     archive_path: []const u8,
 ) !void {
+    var parsed = try release_metadata.parse(init.gpa);
+    defer parsed.deinit();
+    const expected = parsed.value.code_archive;
+
+    const version = try runZig(init, &.{ zig_exe, "version" }, "zig version");
+    defer init.gpa.free(version.stdout);
+    defer init.gpa.free(version.stderr);
+    verifyCommandOutput(
+        version.stdout,
+        expected.zig_version,
+        error.ZigVersionMismatch,
+    ) catch |err| {
+        std.log.err(
+            "Zig version mismatch: expected {s}, got {s}",
+            .{ expected.zig_version, std.mem.trim(u8, version.stdout, " \r\n\t") },
+        );
+        return err;
+    };
+
     const archive_bytes = try std.Io.Dir.cwd().readFileAlloc(
         init.io,
         archive_path,
@@ -39,26 +98,52 @@ fn verifyArchive(
         .limited(maximum_archive_bytes),
     );
     defer init.gpa.free(archive_bytes);
-    try verifyArchiveSha256(archive_bytes, expected_archive_sha256);
+    const initial_comparison = compareArchiveSha256(archive_bytes, expected.sha256);
+    if (!initial_comparison.matches) {
+        std.log.err(
+            "archive SHA-256 mismatch: expected {s}, got {s}",
+            .{ expected.sha256, initial_comparison.actual },
+        );
+        return error.ArchiveSha256Mismatch;
+    }
 
-    const result = try std.process.run(init.gpa, init.io, .{
-        .argv = &.{ zig_exe, "fetch", archive_path },
-        .stdout_limit = .limited(1024),
-        .stderr_limit = .limited(16 * 1024),
-    });
+    const result = try runZig(
+        init,
+        &.{ zig_exe, "fetch", archive_path },
+        "zig fetch",
+    );
     defer init.gpa.free(result.stdout);
     defer init.gpa.free(result.stderr);
-    switch (result.term) {
-        .exited => |code| if (code != 0) {
-            std.log.err("zig fetch failed for '{s}': {s}", .{ archive_path, result.stderr });
-            return error.ZigFetchFailed;
-        },
-        else => {
-            std.log.err("zig fetch terminated abnormally for '{s}'", .{archive_path});
-            return error.ZigFetchFailed;
-        },
+    verifyCommandOutput(
+        result.stdout,
+        expected.zig_package_hash,
+        error.PackageHashMismatch,
+    ) catch |err| {
+        std.log.err(
+            "Zig package hash mismatch: expected {s}, got {s}",
+            .{
+                expected.zig_package_hash,
+                std.mem.trim(u8, result.stdout, " \r\n\t"),
+            },
+        );
+        return err;
+    };
+
+    const retained_bytes = try std.Io.Dir.cwd().readFileAlloc(
+        init.io,
+        archive_path,
+        init.gpa,
+        .limited(maximum_archive_bytes),
+    );
+    defer init.gpa.free(retained_bytes);
+    if (!std.mem.eql(u8, archive_bytes, retained_bytes)) {
+        const retained_sha256 = archiveSha256(retained_bytes);
+        std.log.err(
+            "archive changed during verification: initial {s}, retained {s}",
+            .{ initial_comparison.actual, retained_sha256 },
+        );
+        return error.ArchiveSnapshotChanged;
     }
-    try verifyPackageHash(result.stdout, expected_package_hash);
 }
 
 /// Verifies one local Boundary v0.7.0 archive against both reviewed identities.
@@ -70,20 +155,51 @@ pub fn main(init: std.process.Init) anyerror!void {
         return error.InvalidArguments;
     };
     const archive_path = args.next() orelse {
-        std.log.err("usage: boundary-release-archive-check <zig-exe> <archive-path>", .{});
+        std.log.err(
+            "missing archive; pass -Dboundary-release-archive=/path/to/boundary-v0.7.0.tar.gz",
+            .{},
+        );
         return error.InvalidArguments;
     };
+    if (archive_path.len == 0) {
+        std.log.err(
+            "missing archive; pass -Dboundary-release-archive=/path/to/boundary-v0.7.0.tar.gz",
+            .{},
+        );
+        return error.InvalidArguments;
+    }
     if (args.next() != null) return error.InvalidArguments;
     try verifyArchive(init, zig_exe, archive_path);
 }
 
-test "release archive falsifiers reject wrong byte and package identities" {
+test "release archive falsifiers retain wrong byte and command identities" {
+    var parsed = try release_metadata.parse(std.testing.allocator);
+    defer parsed.deinit();
+    const expected = parsed.value.code_archive;
+
+    const rejected_bytes = "not the reviewed archive";
+    const archive_comparison = compareArchiveSha256(rejected_bytes, expected.sha256);
+    const rejected_sha256 = archiveSha256(rejected_bytes);
+    try std.testing.expect(!archive_comparison.matches);
+    try std.testing.expectEqualStrings(&rejected_sha256, &archive_comparison.actual);
     try std.testing.expectError(
         error.ArchiveSha256Mismatch,
-        verifyArchiveSha256("not the reviewed archive", expected_archive_sha256),
+        verifyArchiveSha256(rejected_bytes, expected.sha256),
     );
     try std.testing.expectError(
         error.PackageHashMismatch,
-        verifyPackageHash("boundary-floating-branch\n", expected_package_hash),
+        verifyCommandOutput(
+            "boundary-floating-branch\n",
+            expected.zig_package_hash,
+            error.PackageHashMismatch,
+        ),
+    );
+    try std.testing.expectError(
+        error.ZigVersionMismatch,
+        verifyCommandOutput(
+            "0.17.0-dev\n",
+            expected.zig_version,
+            error.ZigVersionMismatch,
+        ),
     );
 }

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -21,11 +21,14 @@ const ArchiveSnapshot = struct {
     directory_path: []u8,
     archive_path: []u8,
 
-    fn create(init: std.process.Init, archive_bytes: []const u8) !ArchiveSnapshot {
+    fn create(
+        init: std.process.Init,
+        temporary_root: []const u8,
+        archive_bytes: []const u8,
+    ) !ArchiveSnapshot {
         var random_bytes: [16]u8 = @splat(0);
         init.io.random(&random_bytes);
         const suffix = std.fmt.bytesToHex(random_bytes, .lower);
-        const temporary_root = init.environ_map.get("TMPDIR") orelse "/tmp";
         const directory_path = try std.fmt.allocPrint(
             init.gpa,
             "{s}/boundary-release-archive-{s}",
@@ -55,6 +58,21 @@ const ArchiveSnapshot = struct {
         });
         defer file.close(init.io);
         try file.writeStreamingAll(init.io, archive_bytes);
+
+        const build_path = try std.Io.Dir.path.join(
+            init.gpa,
+            &.{ directory_path, "build.zig" },
+        );
+        defer init.gpa.free(build_path);
+        var build_file = try std.Io.Dir.createFileAbsolute(init.io, build_path, .{
+            .exclusive = true,
+            .permissions = @enumFromInt(0o600),
+        });
+        defer build_file.close(init.io);
+        try build_file.writeStreamingAll(
+            init.io,
+            "pub fn build(_: *@import(\"std\").Build) void {}\n",
+        );
 
         return .{
             .directory_path = directory_path,
@@ -109,9 +127,11 @@ fn runZig(
     init: std.process.Init,
     argv: []const []const u8,
     failure_label: []const u8,
+    cwd: std.process.Child.Cwd,
 ) !std.process.RunResult {
     const result = try std.process.run(init.gpa, init.io, .{
         .argv = argv,
+        .cwd = cwd,
         .stdout_limit = .limited(1024),
         .stderr_limit = .limited(16 * 1024),
     });
@@ -130,6 +150,7 @@ fn verifyArchive(
     zig_exe: []const u8,
     archive_path: []const u8,
     global_cache_path: []const u8,
+    proof_root: []const u8,
 ) !void {
     var parsed = try release_metadata.parse(init.gpa);
     defer parsed.deinit();
@@ -142,7 +163,12 @@ fn verifyArchive(
         return error.MetadataIdentityMismatch;
     };
 
-    const version = try runZig(init, &.{ zig_exe, "version" }, "zig version");
+    const version = try runZig(
+        init,
+        &.{ zig_exe, "version" },
+        "zig version",
+        .inherit,
+    );
     defer init.gpa.free(version.stdout);
     defer init.gpa.free(version.stderr);
     verifyCommandOutput(
@@ -173,7 +199,7 @@ fn verifyArchive(
         return error.ArchiveSha256Mismatch;
     }
 
-    var snapshot = try ArchiveSnapshot.create(init, archive_bytes);
+    var snapshot = try ArchiveSnapshot.create(init, proof_root, archive_bytes);
     defer snapshot.deinit(init);
     const result = try runZig(
         init,
@@ -185,6 +211,7 @@ fn verifyArchive(
             snapshot.archive_path,
         },
         "zig fetch",
+        .{ .path = snapshot.directory_path },
     );
     defer init.gpa.free(result.stdout);
     defer init.gpa.free(result.stderr);
@@ -202,7 +229,6 @@ fn verifyArchive(
         );
         return err;
     };
-
 }
 
 /// Verifies one local Boundary v0.7.0 archive against both reviewed identities.
@@ -211,7 +237,7 @@ pub fn main(init: std.process.Init) anyerror!void {
     _ = args.next();
     const zig_exe = args.next() orelse {
         std.log.err(
-            "usage: boundary-release-archive-check <zig-exe> <archive-path> <global-cache-path>",
+            "usage: boundary-release-archive-check <zig-exe> <archive-path> <global-cache-path> <proof-root>",
             .{},
         );
         return error.InvalidArguments;
@@ -238,8 +264,25 @@ pub fn main(init: std.process.Init) anyerror!void {
         return error.InvalidArguments;
     };
     if (global_cache_path.len == 0) return error.InvalidArguments;
+    const proof_root = args.next() orelse {
+        std.log.err(
+            "missing proof root; the caller must provide an absolute writable workspace",
+            .{},
+        );
+        return error.InvalidArguments;
+    };
+    if (proof_root.len == 0 or !std.Io.Dir.path.isAbsolute(proof_root)) {
+        std.log.err("proof root must be an absolute writable directory", .{});
+        return error.InvalidArguments;
+    }
     if (args.next() != null) return error.InvalidArguments;
-    try verifyArchive(init, zig_exe, archive_path, global_cache_path);
+    try verifyArchive(
+        init,
+        zig_exe,
+        archive_path,
+        global_cache_path,
+        proof_root,
+    );
 }
 
 test "release archive falsifiers retain wrong byte and command identities" {

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -8,6 +8,7 @@ const VerificationError = error{
     ArchiveSnapshotChanged,
     ArchiveSha256Mismatch,
     PackageHashMismatch,
+    MetadataIdentityMismatch,
     ZigVersionMismatch,
     ZigFetchFailed,
 };
@@ -75,6 +76,13 @@ fn verifyArchive(
     var parsed = try release_metadata.parse(init.gpa);
     defer parsed.deinit();
     const expected = parsed.value.code_archive;
+    release_metadata.validateCodeArchive(expected) catch |err| {
+        std.log.err(
+            "release metadata does not match the fixed Boundary v0.7.0 oracle: {s}",
+            .{@errorName(err)},
+        );
+        return error.MetadataIdentityMismatch;
+    };
 
     const version = try runZig(init, &.{ zig_exe, "version" }, "zig version");
     defer init.gpa.free(version.stdout);
@@ -176,6 +184,13 @@ test "release archive falsifiers retain wrong byte and command identities" {
     var parsed = try release_metadata.parse(std.testing.allocator);
     defer parsed.deinit();
     const expected = parsed.value.code_archive;
+
+    var drifted = expected;
+    drifted.commit = "0000000000000000000000000000000000000000";
+    try std.testing.expectError(
+        error.CodeArchiveIdentityMismatch,
+        release_metadata.validateCodeArchive(drifted),
+    );
 
     const rejected_bytes = "not the reviewed archive";
     const archive_comparison = compareArchiveSha256(rejected_bytes, expected.sha256);

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -18,6 +18,64 @@ const ArchiveSha256Comparison = struct {
     matches: bool,
 };
 
+const ArchiveSnapshot = struct {
+    directory_path: []u8,
+    archive_path: []u8,
+
+    fn create(init: std.process.Init, archive_bytes: []const u8) !ArchiveSnapshot {
+        var random_bytes: [16]u8 = @splat(0);
+        init.io.random(&random_bytes);
+        const suffix = std.fmt.bytesToHex(random_bytes, .lower);
+        const temporary_root = init.environ_map.get("TMPDIR") orelse "/tmp";
+        const directory_path = try std.fmt.allocPrint(
+            init.gpa,
+            "{s}/boundary-release-archive-{s}",
+            .{ temporary_root, suffix },
+        );
+        errdefer init.gpa.free(directory_path);
+        try std.Io.Dir.createDirAbsolute(
+            init.io,
+            directory_path,
+            @enumFromInt(0o700),
+        );
+        errdefer std.Io.Dir.cwd().deleteTree(init.io, directory_path) catch |err| {
+            std.log.warn(
+                "could not remove failed private archive snapshot {s}: {s}",
+                .{ directory_path, @errorName(err) },
+            );
+        };
+
+        const archive_path = try std.Io.Dir.path.join(
+            init.gpa,
+            &.{ directory_path, "boundary-v0.7.0.tar.gz" },
+        );
+        errdefer init.gpa.free(archive_path);
+        var file = try std.Io.Dir.createFileAbsolute(init.io, archive_path, .{
+            .exclusive = true,
+            .permissions = @enumFromInt(0o600),
+        });
+        defer file.close(init.io);
+        try file.writeStreamingAll(init.io, archive_bytes);
+
+        return .{
+            .directory_path = directory_path,
+            .archive_path = archive_path,
+        };
+    }
+
+    fn deinit(snapshot: *ArchiveSnapshot, init: std.process.Init) void {
+        std.Io.Dir.cwd().deleteTree(init.io, snapshot.directory_path) catch |err| {
+            std.log.warn(
+                "could not remove private archive snapshot {s}: {s}",
+                .{ snapshot.directory_path, @errorName(err) },
+            );
+        };
+        init.gpa.free(snapshot.archive_path);
+        init.gpa.free(snapshot.directory_path);
+        snapshot.* = undefined;
+    }
+};
+
 fn archiveSha256(bytes: []const u8) [64]u8 {
     var digest: [32]u8 = @splat(0);
     std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
@@ -72,6 +130,7 @@ fn verifyArchive(
     init: std.process.Init,
     zig_exe: []const u8,
     archive_path: []const u8,
+    global_cache_path: []const u8,
 ) !void {
     var parsed = try release_metadata.parse(init.gpa);
     defer parsed.deinit();
@@ -115,9 +174,17 @@ fn verifyArchive(
         return error.ArchiveSha256Mismatch;
     }
 
+    var snapshot = try ArchiveSnapshot.create(init, archive_bytes);
+    defer snapshot.deinit(init);
     const result = try runZig(
         init,
-        &.{ zig_exe, "fetch", archive_path },
+        &.{
+            zig_exe,
+            "fetch",
+            "--global-cache-dir",
+            global_cache_path,
+            snapshot.archive_path,
+        },
         "zig fetch",
     );
     defer init.gpa.free(result.stdout);
@@ -176,14 +243,23 @@ pub fn main(init: std.process.Init) anyerror!void {
         );
         return error.InvalidArguments;
     }
+    const global_cache_path = args.next() orelse {
+        std.log.err(
+            "missing global cache path; the caller must bind every nested Zig process to one cache",
+            .{},
+        );
+        return error.InvalidArguments;
+    };
+    if (global_cache_path.len == 0) return error.InvalidArguments;
     if (args.next() != null) return error.InvalidArguments;
-    try verifyArchive(init, zig_exe, archive_path);
+    try verifyArchive(init, zig_exe, archive_path, global_cache_path);
 }
 
 test "release archive falsifiers retain wrong byte and command identities" {
     var parsed = try release_metadata.parse(std.testing.allocator);
     defer parsed.deinit();
     const expected = parsed.value.code_archive;
+    try release_metadata.validateCodeArchive(expected);
 
     var drifted = expected;
     drifted.commit = "0000000000000000000000000000000000000000";

--- a/conformance/static-machine-v1/release_archive_check.zig
+++ b/conformance/static-machine-v1/release_archive_check.zig
@@ -5,7 +5,6 @@ const std = @import("std");
 const maximum_archive_bytes = 32 * 1024 * 1024;
 
 const VerificationError = error{
-    ArchiveSnapshotChanged,
     ArchiveSha256Mismatch,
     PackageHashMismatch,
     MetadataIdentityMismatch,
@@ -204,21 +203,6 @@ fn verifyArchive(
         return err;
     };
 
-    const retained_bytes = try std.Io.Dir.cwd().readFileAlloc(
-        init.io,
-        archive_path,
-        init.gpa,
-        .limited(maximum_archive_bytes),
-    );
-    defer init.gpa.free(retained_bytes);
-    if (!std.mem.eql(u8, archive_bytes, retained_bytes)) {
-        const retained_sha256 = archiveSha256(retained_bytes);
-        std.log.err(
-            "archive changed during verification: initial {s}, retained {s}",
-            .{ initial_comparison.actual, retained_sha256 },
-        );
-        return error.ArchiveSnapshotChanged;
-    }
 }
 
 /// Verifies one local Boundary v0.7.0 archive against both reviewed identities.
@@ -226,7 +210,10 @@ pub fn main(init: std.process.Init) anyerror!void {
     var args = std.process.Args.Iterator.init(init.minimal.args);
     _ = args.next();
     const zig_exe = args.next() orelse {
-        std.log.err("usage: boundary-release-archive-check <zig-exe> <archive-path>", .{});
+        std.log.err(
+            "usage: boundary-release-archive-check <zig-exe> <archive-path> <global-cache-path>",
+            .{},
+        );
         return error.InvalidArguments;
     };
     const archive_path = args.next() orelse {
@@ -260,6 +247,20 @@ test "release archive falsifiers retain wrong byte and command identities" {
     defer parsed.deinit();
     const expected = parsed.value.code_archive;
     try release_metadata.validateCodeArchive(expected);
+
+    const accepted_bytes = "focused archive predicate baseline";
+    const accepted_sha256 = archiveSha256(accepted_bytes);
+    try verifyArchiveSha256(accepted_bytes, &accepted_sha256);
+    try verifyCommandOutput(
+        expected.zig_package_hash,
+        expected.zig_package_hash,
+        error.PackageHashMismatch,
+    );
+    try verifyCommandOutput(
+        expected.zig_version,
+        expected.zig_version,
+        error.ZigVersionMismatch,
+    );
 
     var drifted = expected;
     drifted.commit = "0000000000000000000000000000000000000000";

--- a/conformance/static-machine-v1/release_archive_check_offline.sh
+++ b/conformance/static-machine-v1/release_archive_check_offline.sh
@@ -9,6 +9,24 @@ fi
 
 zig_exe=$1
 reviewed_archive=$2
+
+absolute_path() {
+    path_input=$1
+    case "$path_input" in
+        /*) printf '%s\n' "$path_input" ;;
+        */*)
+            path_leaf=${path_input##*/}
+            path_directory=${path_input%/*}
+            path_directory=$(
+                CDPATH= cd -- "$path_directory" &&
+                    pwd
+            ) || return
+            printf '%s/%s\n' "$path_directory" "$path_leaf"
+            ;;
+        *) printf '%s/%s\n' "$PWD" "$path_input" ;;
+    esac
+}
+
 case "$zig_exe" in
     */*) ;;
     *)
@@ -18,53 +36,63 @@ case "$zig_exe" in
         }
         ;;
 esac
-case "$zig_exe" in
-    /*) ;;
-    *)
-        zig_exe=$(
-            CDPATH= cd -- "$(dirname "$zig_exe")" &&
-                printf '%s/%s\n' "$PWD" "$(basename "$zig_exe")"
-        )
-        ;;
-esac
+zig_exe=$(absolute_path "$zig_exe")
 case "$reviewed_archive" in
     -*) reviewed_archive="./$reviewed_archive" ;;
 esac
-case "$reviewed_archive" in
-    /*) ;;
-    *)
-        reviewed_archive=$(
-            CDPATH= cd -- "$(dirname "$reviewed_archive")" &&
-                printf '%s/%s\n' "$PWD" "$(basename "$reviewed_archive")"
-        )
-        ;;
-esac
+reviewed_archive=$(absolute_path "$reviewed_archive")
 script_directory=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 repository_root=$(CDPATH= cd -- "$script_directory/../.." && pwd)
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-offline.XXXXXX")
 proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
 child_pid=
+cleanup_allowed=yes
 
 cleanup() {
+    if [ "$cleanup_allowed" != yes ]; then
+        printf 'retaining proof root after incomplete process-group shutdown: %s\n' \
+            "$proof_root" >&2
+        return
+    fi
     case "$proof_root" in
         */boundary-release-archive-offline.*) rm -rf "$proof_root" ;;
         *) printf 'refusing to remove unexpected proof root: %s\n' "$proof_root" >&2 ;;
     esac
 }
+terminate_child() {
+    if [ -n "$child_pid" ]; then
+        terminating_pid=$child_pid
+        # Direct-first covers pre-setpgid cancellation; group-second closes
+        # the spawn race after the helper owns its process group.
+        kill -TERM "$terminating_pid" 2>/dev/null || :
+        kill -TERM -"$terminating_pid" 2>/dev/null || :
+        wait "$child_pid" 2>/dev/null || :
+        shutdown_attempt=0
+        while kill -0 -"$terminating_pid" 2>/dev/null; do
+            shutdown_attempt=$((shutdown_attempt + 1))
+            if [ "$shutdown_attempt" -eq 4 ]; then
+                kill -KILL -"$terminating_pid" 2>/dev/null || :
+            fi
+            if [ "$shutdown_attempt" -ge 8 ]; then
+                cleanup_allowed=no
+                child_pid=
+                return 1
+            fi
+            sleep 1
+        done
+        child_pid=
+    fi
+}
 on_signal() {
     signal_status=$1
-    if [ -n "$child_pid" ]; then
-        kill -TERM "$child_pid" 2>/dev/null || :
-        wait "$child_pid" 2>/dev/null || :
-    fi
+    terminate_child || :
     exit "$signal_status"
 }
 trap cleanup EXIT
 trap 'on_signal 129' HUP
 trap 'on_signal 130' INT
 trap 'on_signal 143' TERM
-trap >"$proof_root/trap-state"
-if ! grep -Fq 'on_signal 130' "$proof_root/trap-state"; then
+if ! sh -c 'trap "exit 0" INT; kill -INT "$$"; exit 1'; then
     printf '%s\n' 'release archive check signal handler unavailable: INT' >&2
     exit 2
 fi
@@ -72,8 +100,31 @@ fi
 local_cache="$proof_root/local-cache"
 global_cache="$proof_root/global-cache"
 mkdir -p "$local_cache" "$global_cache"
+process_group_exe="$proof_root/boundary-release-process-group"
+process_group_ready="$proof_root/process-group-ready"
+completion_receipt="$proof_root/archive-check-complete"
 
-"$zig_exe" run \
+"$zig_exe" build-exe \
+    --cache-dir "$local_cache" \
+    --global-cache-dir "$global_cache" \
+    -OReleaseSafe \
+    -femit-bin="$process_group_exe" \
+    "$repository_root/conformance/static-machine-v1/release_process_group.zig" &
+child_pid=$!
+if wait "$child_pid"; then
+    child_status=0
+else
+    child_status=$?
+fi
+child_pid=
+if [ "$child_status" -ne 0 ] || [ ! -x "$process_group_exe" ]; then
+    printf '%s\n' 'release archive check process-group helper build failed' >&2
+    exit 2
+fi
+
+"$process_group_exe" \
+    "$process_group_ready" \
+    "$zig_exe" run \
     --cache-dir "$local_cache" \
     --global-cache-dir "$global_cache" \
     --dep boundary_static_machine_release_metadata \
@@ -83,12 +134,52 @@ mkdir -p "$local_cache" "$global_cache"
     "$zig_exe" \
     "$reviewed_archive" \
     "$global_cache" \
-    "$proof_root" &
+    "$proof_root" \
+    "$completion_receipt" &
 child_pid=$!
+while [ ! -f "$process_group_ready" ]; do
+    if ! kill -0 "$child_pid" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+ready_line=
+if [ -f "$process_group_ready" ]; then
+    IFS= read -r ready_line <"$process_group_ready" || :
+fi
+if [ "$ready_line" != "boundary-release-process-group/v1 $child_pid" ]; then
+    terminate_child || :
+    printf '%s\n' 'release archive check process-group helper did not become ready' >&2
+    exit 2
+fi
 if wait "$child_pid"; then
     child_status=0
 else
     child_status=$?
 fi
 child_pid=
-exit "$child_status"
+if [ "$child_status" -ne 0 ]; then
+    exit "$child_status"
+fi
+if [ ! -f "$completion_receipt" ]; then
+    printf '%s\n' 'release archive checker did not write its completion receipt' >&2
+    exit 2
+fi
+exec 3<"$completion_receipt"
+completion_line=
+completion_valid=yes
+if ! IFS= read -r completion_line <&3 ||
+    [ "$completion_line" != 'boundary-release-archive-check/v1' ]
+then
+    completion_valid=no
+else
+    completion_extra=
+    if IFS= read -r completion_extra <&3 || [ -n "$completion_extra" ]; then
+        completion_valid=no
+    fi
+fi
+exec 3<&-
+if [ "$completion_valid" != yes ]; then
+    printf '%s\n' 'release archive checker wrote an invalid completion receipt' >&2
+    exit 2
+fi

--- a/conformance/static-machine-v1/release_archive_check_offline.sh
+++ b/conformance/static-machine-v1/release_archive_check_offline.sh
@@ -28,6 +28,9 @@ case "$zig_exe" in
         ;;
 esac
 case "$reviewed_archive" in
+    -*) reviewed_archive="./$reviewed_archive" ;;
+esac
+case "$reviewed_archive" in
     /*) ;;
     *)
         reviewed_archive=$(
@@ -47,7 +50,13 @@ cleanup() {
         *) printf 'refusing to remove unexpected proof root: %s\n' "$proof_root" >&2 ;;
     esac
 }
-trap cleanup EXIT HUP INT TERM
+on_signal() {
+    exit "$1"
+}
+trap cleanup EXIT
+trap 'on_signal 129' HUP
+trap 'on_signal 130' INT
+trap 'on_signal 143' TERM
 
 local_cache="$proof_root/local-cache"
 global_cache="$proof_root/global-cache"

--- a/conformance/static-machine-v1/release_archive_check_offline.sh
+++ b/conformance/static-machine-v1/release_archive_check_offline.sh
@@ -43,6 +43,7 @@ script_directory=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 repository_root=$(CDPATH= cd -- "$script_directory/../.." && pwd)
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-offline.XXXXXX")
 proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
+child_pid=
 
 cleanup() {
     case "$proof_root" in
@@ -51,12 +52,22 @@ cleanup() {
     esac
 }
 on_signal() {
-    exit "$1"
+    signal_status=$1
+    if [ -n "$child_pid" ]; then
+        kill -TERM "$child_pid" 2>/dev/null || :
+        wait "$child_pid" 2>/dev/null || :
+    fi
+    exit "$signal_status"
 }
 trap cleanup EXIT
 trap 'on_signal 129' HUP
 trap 'on_signal 130' INT
 trap 'on_signal 143' TERM
+trap >"$proof_root/trap-state"
+if ! grep -Fq 'on_signal 130' "$proof_root/trap-state"; then
+    printf '%s\n' 'release archive check signal handler unavailable: INT' >&2
+    exit 2
+fi
 
 local_cache="$proof_root/local-cache"
 global_cache="$proof_root/global-cache"
@@ -72,4 +83,12 @@ mkdir -p "$local_cache" "$global_cache"
     "$zig_exe" \
     "$reviewed_archive" \
     "$global_cache" \
-    "$proof_root"
+    "$proof_root" &
+child_pid=$!
+if wait "$child_pid"; then
+    child_status=0
+else
+    child_status=$?
+fi
+child_pid=
+exit "$child_status"

--- a/conformance/static-machine-v1/release_archive_check_offline.sh
+++ b/conformance/static-machine-v1/release_archive_check_offline.sh
@@ -9,9 +9,34 @@ fi
 
 zig_exe=$1
 reviewed_archive=$2
+case "$zig_exe" in
+    /*) ;;
+    */*)
+        zig_exe=$(
+            CDPATH= cd -- "$(dirname "$zig_exe")" &&
+                printf '%s/%s\n' "$PWD" "$(basename "$zig_exe")"
+        )
+        ;;
+    *)
+        zig_exe=$(command -v "$zig_exe") || {
+            printf 'zig executable not found: %s\n' "$zig_exe" >&2
+            exit 2
+        }
+        ;;
+esac
+case "$reviewed_archive" in
+    /*) ;;
+    *)
+        reviewed_archive=$(
+            CDPATH= cd -- "$(dirname "$reviewed_archive")" &&
+                printf '%s/%s\n' "$PWD" "$(basename "$reviewed_archive")"
+        )
+        ;;
+esac
 script_directory=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 repository_root=$(CDPATH= cd -- "$script_directory/../.." && pwd)
 proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-offline.XXXXXX")
+proof_root=$(CDPATH= cd -- "$proof_root" && pwd)
 
 cleanup() {
     case "$proof_root" in
@@ -24,17 +49,15 @@ trap cleanup EXIT HUP INT TERM
 local_cache="$proof_root/local-cache"
 global_cache="$proof_root/global-cache"
 mkdir -p "$local_cache" "$global_cache"
+cd "$repository_root"
 
-(
-    cd "$repository_root"
-    "$zig_exe" run \
-        --cache-dir "$local_cache" \
-        --global-cache-dir "$global_cache" \
-        --dep boundary_static_machine_release_metadata \
-        -Mroot=conformance/static-machine-v1/release_archive_check.zig \
-        -Mboundary_static_machine_release_metadata=conformance/static-machine-v1/release_metadata.zig \
-        -- \
-        "$zig_exe" \
-        "$reviewed_archive" \
-        "$global_cache"
-)
+"$zig_exe" run \
+    --cache-dir "$local_cache" \
+    --global-cache-dir "$global_cache" \
+    --dep boundary_static_machine_release_metadata \
+    -Mroot="$repository_root/conformance/static-machine-v1/release_archive_check.zig" \
+    -Mboundary_static_machine_release_metadata="$repository_root/conformance/static-machine-v1/release_metadata.zig" \
+    -- \
+    "$zig_exe" \
+    "$reviewed_archive" \
+    "$global_cache"

--- a/conformance/static-machine-v1/release_archive_check_offline.sh
+++ b/conformance/static-machine-v1/release_archive_check_offline.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+    printf '%s\n' \
+        'usage: release_archive_check_offline.sh <zig-exe> <reviewed-archive>' >&2
+    exit 2
+fi
+
+zig_exe=$1
+reviewed_archive=$2
+script_directory=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "$script_directory/../.." && pwd)
+proof_root=$(mktemp -d "${TMPDIR:-/tmp}/boundary-release-archive-offline.XXXXXX")
+
+cleanup() {
+    case "$proof_root" in
+        */boundary-release-archive-offline.*) rm -rf "$proof_root" ;;
+        *) printf 'refusing to remove unexpected proof root: %s\n' "$proof_root" >&2 ;;
+    esac
+}
+trap cleanup EXIT HUP INT TERM
+
+local_cache="$proof_root/local-cache"
+global_cache="$proof_root/global-cache"
+mkdir -p "$local_cache" "$global_cache"
+
+(
+    cd "$repository_root"
+    "$zig_exe" run \
+        --cache-dir "$local_cache" \
+        --global-cache-dir "$global_cache" \
+        --dep boundary_static_machine_release_metadata \
+        -Mroot=conformance/static-machine-v1/release_archive_check.zig \
+        -Mboundary_static_machine_release_metadata=conformance/static-machine-v1/release_metadata.zig \
+        -- \
+        "$zig_exe" \
+        "$reviewed_archive" \
+        "$global_cache"
+)

--- a/conformance/static-machine-v1/release_archive_check_offline.sh
+++ b/conformance/static-machine-v1/release_archive_check_offline.sh
@@ -10,18 +10,21 @@ fi
 zig_exe=$1
 reviewed_archive=$2
 case "$zig_exe" in
-    /*) ;;
-    */*)
-        zig_exe=$(
-            CDPATH= cd -- "$(dirname "$zig_exe")" &&
-                printf '%s/%s\n' "$PWD" "$(basename "$zig_exe")"
-        )
-        ;;
+    */*) ;;
     *)
         zig_exe=$(command -v "$zig_exe") || {
             printf 'zig executable not found: %s\n' "$zig_exe" >&2
             exit 2
         }
+        ;;
+esac
+case "$zig_exe" in
+    /*) ;;
+    *)
+        zig_exe=$(
+            CDPATH= cd -- "$(dirname "$zig_exe")" &&
+                printf '%s/%s\n' "$PWD" "$(basename "$zig_exe")"
+        )
         ;;
 esac
 case "$reviewed_archive" in
@@ -49,7 +52,6 @@ trap cleanup EXIT HUP INT TERM
 local_cache="$proof_root/local-cache"
 global_cache="$proof_root/global-cache"
 mkdir -p "$local_cache" "$global_cache"
-cd "$repository_root"
 
 "$zig_exe" run \
     --cache-dir "$local_cache" \
@@ -60,4 +62,5 @@ cd "$repository_root"
     -- \
     "$zig_exe" \
     "$reviewed_archive" \
-    "$global_cache"
+    "$global_cache" \
+    "$proof_root"

--- a/conformance/static-machine-v1/release_metadata.zig
+++ b/conformance/static-machine-v1/release_metadata.zig
@@ -1,0 +1,57 @@
+const std = @import("std");
+
+const metadata_bytes = @embedFile("release-metadata.json");
+
+/// Identifies the reviewed Boundary source archive and its verifier toolchain.
+pub const CodeArchive = struct {
+    tag: []const u8,
+    commit: []const u8,
+    url: []const u8,
+    sha256: []const u8,
+    zig_package_hash: []const u8,
+    zig_version: []const u8,
+};
+
+/// Binds one documentation-supplement path to its SHA-256 digest.
+pub const SupplementFile = struct {
+    path: []const u8,
+    sha256: []const u8,
+};
+
+/// Distinguishes post-tag release documentation from the immutable code archive.
+pub const DocumentationSupplement = struct {
+    included_in_code_archive: bool,
+    identity_kind: []const u8,
+    publication_binding: []const u8,
+    files: []const SupplementFile,
+};
+
+/// Records the owner-derived StaticMachine ABI v1 compatibility surface.
+pub const StaticMachineAbi = struct {
+    version: u32,
+    constructor: []const u8,
+    options: []const u8,
+    state_encoding: []const u8,
+    world_ports: []const u8,
+    compatibility_document: []const u8,
+    supported_contracts: []const []const u8,
+    unsupported_contracts: []const []const u8,
+};
+
+/// Carries the complete Boundary StaticMachine release receipt.
+pub const ReleaseMetadata = struct {
+    schema: []const u8,
+    code_archive: CodeArchive,
+    documentation_supplement: DocumentationSupplement,
+    static_machine_abi: StaticMachineAbi,
+};
+
+/// Parses the checked release receipt without tolerating unknown fields.
+pub fn parse(allocator: std.mem.Allocator) !std.json.Parsed(ReleaseMetadata) {
+    return std.json.parseFromSlice(
+        ReleaseMetadata,
+        allocator,
+        metadata_bytes,
+        .{ .ignore_unknown_fields = false },
+    );
+}

--- a/conformance/static-machine-v1/release_metadata.zig
+++ b/conformance/static-machine-v1/release_metadata.zig
@@ -12,6 +12,30 @@ pub const CodeArchive = struct {
     zig_version: []const u8,
 };
 
+/// Fixed acceptance oracle for the reviewed Boundary v0.7.0 code archive.
+pub const reviewed_code_archive = CodeArchive{
+    .tag = "v0.7.0",
+    .commit = "7f2472100454aa2cd5c62e07db0c1e23eaf46a77",
+    .url = "https://github.com/tkersey/boundary/archive/refs/tags/v0.7.0.tar.gz",
+    .sha256 = "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a",
+    .zig_package_hash = "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_",
+    .zig_version = "0.16.0",
+};
+
+/// Rejects release metadata that differs from the fixed v0.7.0 oracle.
+pub fn validateCodeArchive(actual: CodeArchive) error{CodeArchiveIdentityMismatch}!void {
+    const expected = reviewed_code_archive;
+    if (!std.mem.eql(u8, actual.tag, expected.tag) or
+        !std.mem.eql(u8, actual.commit, expected.commit) or
+        !std.mem.eql(u8, actual.url, expected.url) or
+        !std.mem.eql(u8, actual.sha256, expected.sha256) or
+        !std.mem.eql(u8, actual.zig_package_hash, expected.zig_package_hash) or
+        !std.mem.eql(u8, actual.zig_version, expected.zig_version))
+    {
+        return error.CodeArchiveIdentityMismatch;
+    }
+}
+
 /// Binds one documentation-supplement path to its SHA-256 digest.
 pub const SupplementFile = struct {
     path: []const u8,

--- a/conformance/static-machine-v1/release_process_group.zig
+++ b/conformance/static-machine-v1/release_process_group.zig
@@ -1,0 +1,80 @@
+// zlinter-disable require_errdefer_dealloc
+const std = @import("std");
+
+const ProcessGroupError = error{
+    InvalidArguments,
+    ProcessGroupUnavailable,
+};
+
+fn establishProcessGroup() ProcessGroupError!std.posix.pid_t {
+    switch (std.posix.errno(std.posix.system.setpgid(0, 0))) {
+        .SUCCESS => {},
+        else => return error.ProcessGroupUnavailable,
+    }
+    return std.posix.system.getpid();
+}
+
+fn writeReady(
+    init: std.process.Init,
+    ready_path: []const u8,
+    process_group: std.posix.pid_t,
+) !void {
+    const receipt = try std.fmt.allocPrint(
+        init.gpa,
+        "boundary-release-process-group/v1 {d}\n",
+        .{process_group},
+    );
+    defer init.gpa.free(receipt);
+    var ready = try std.Io.Dir.createFileAbsolute(init.io, ready_path, .{
+        .exclusive = true,
+        .permissions = @enumFromInt(0o600),
+    });
+    defer ready.close(init.io);
+    try ready.writeStreamingAll(init.io, receipt);
+}
+
+/// Establishes one verifier-owned process group before launching any verifier
+/// process. The readiness receipt binds the helper PID to that group before the
+/// shell accepts the verifier launch.
+pub fn main(init: std.process.Init) anyerror!void {
+    var args = std.process.Args.Iterator.init(init.minimal.args);
+    _ = args.next();
+    const ready_path = args.next() orelse return error.InvalidArguments;
+    if (!std.Io.Dir.path.isAbsolute(ready_path)) return error.InvalidArguments;
+
+    var command: std.ArrayList([]const u8) = .empty;
+    defer command.deinit(init.gpa);
+    while (args.next()) |arg| try command.append(init.gpa, arg);
+    if (command.items.len == 0) return error.InvalidArguments;
+
+    const process_group = try establishProcessGroup();
+    try writeReady(init, ready_path, process_group);
+
+    var child = try std.process.spawn(init.io, .{
+        .argv = command.items,
+        .stdin = .inherit,
+        .stdout = .inherit,
+        .stderr = .inherit,
+        .pgid = process_group,
+    });
+    const term = try child.wait(init.io);
+    switch (term) {
+        .exited => |status| std.process.exit(status),
+        .signal => |signal| std.process.exit(128 + @as(u8, @intCast(@intFromEnum(signal)))),
+        .stopped, .unknown => std.process.exit(1),
+    }
+}
+
+test "readiness receipt names the owned process group" {
+    const process_group: std.posix.pid_t = 42;
+    const receipt = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "boundary-release-process-group/v1 {d}\n",
+        .{process_group},
+    );
+    defer std.testing.allocator.free(receipt);
+    try std.testing.expectEqualStrings(
+        "boundary-release-process-group/v1 42\n",
+        receipt,
+    );
+}

--- a/conformance/static-machine-v1/release_test.zig
+++ b/conformance/static-machine-v1/release_test.zig
@@ -8,17 +8,12 @@ const static_machine_bytes = release_sources.static_machine_bytes;
 const compatibility_bytes = release_sources.compatibility_bytes;
 const release_hardening_bytes = release_sources.release_hardening_bytes;
 
-const expected_commit = "7f2472100454aa2cd5c62e07db0c1e23eaf46a77";
-const expected_archive_url = "https://github.com/tkersey/boundary/archive/refs/tags/v0.7.0.tar.gz";
-const expected_archive_sha256 = "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a";
-const expected_package_hash = "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_";
-const expected_zig_version = "0.16.0";
-
 const ValidationError = error{
     InvalidSchema,
     CodeArchiveIdentityMismatch,
     DocumentationIdentityConflated,
     DocumentationIdentityInvalid,
+    InvalidTextLineEnding,
     StaticMachineAbiMismatch,
     SupportMatrixMismatch,
     CompatibilityClaimMissing,
@@ -78,9 +73,26 @@ const supplement_sources = [_]struct {
     .{ .path = "docs/static_machine_compatibility.md", .bytes = compatibility_bytes },
 };
 
-fn sha256(bytes: []const u8) [64]u8 {
+fn canonicalTextSha256(bytes: []const u8) ValidationError![64]u8 {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var segment_start: usize = 0;
+    var index: usize = 0;
+    while (index < bytes.len) {
+        if (bytes[index] != '\r') {
+            index += 1;
+            continue;
+        }
+        if (index + 1 >= bytes.len or bytes[index + 1] != '\n') {
+            return error.InvalidTextLineEnding;
+        }
+        hasher.update(bytes[segment_start..index]);
+        hasher.update("\n");
+        index += 2;
+        segment_start = index;
+    }
+    hasher.update(bytes[segment_start..]);
     var digest: [32]u8 = @splat(0);
-    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    hasher.final(&digest);
     return std.fmt.bytesToHex(digest, .lower);
 }
 
@@ -119,20 +131,16 @@ fn validateMetadata(metadata: release_metadata.ReleaseMetadata) ValidationError!
         return error.InvalidSchema;
     }
 
-    const archive = metadata.code_archive;
-    if (!std.mem.eql(u8, archive.tag, "v0.7.0") or
-        !std.mem.eql(u8, archive.commit, expected_commit) or
-        !std.mem.eql(u8, archive.url, expected_archive_url) or
-        !std.mem.eql(u8, archive.sha256, expected_archive_sha256) or
-        !std.mem.eql(u8, archive.zig_package_hash, expected_package_hash) or
-        !std.mem.eql(u8, archive.zig_version, expected_zig_version))
-    {
+    release_metadata.validateCodeArchive(metadata.code_archive) catch
         return error.CodeArchiveIdentityMismatch;
-    }
 
     const supplement = metadata.documentation_supplement;
     if (supplement.included_in_code_archive or
-        !std.mem.eql(u8, supplement.identity_kind, "ordered-sha256-file-set-v1") or
+        !std.mem.eql(
+            u8,
+            supplement.identity_kind,
+            "ordered-canonical-text-sha256-file-set-v1",
+        ) or
         !std.mem.eql(u8, supplement.publication_binding, "reviewed-release-closure-git-commit"))
     {
         return error.DocumentationIdentityConflated;
@@ -141,7 +149,7 @@ fn validateMetadata(metadata: release_metadata.ReleaseMetadata) ValidationError!
         return error.DocumentationIdentityInvalid;
     }
     for (supplement.files, supplement_sources) |file, source| {
-        const digest = sha256(source.bytes);
+        const digest = try canonicalTextSha256(source.bytes);
         if (!std.mem.eql(u8, file.path, source.path) or
             !std.mem.eql(u8, file.sha256, &digest))
         {
@@ -266,6 +274,14 @@ test "release metadata falsifiers reject wrong code identity and conflated docum
     var wrong_hash = valid;
     wrong_hash.code_archive.zig_package_hash = "boundary-floating-branch";
     try std.testing.expectError(error.CodeArchiveIdentityMismatch, validateMetadata(wrong_hash));
+
+    const lf_digest = try canonicalTextSha256("first\nsecond\n");
+    const crlf_digest = try canonicalTextSha256("first\r\nsecond\r\n");
+    try std.testing.expectEqualStrings(&lf_digest, &crlf_digest);
+    try std.testing.expectError(
+        error.InvalidTextLineEnding,
+        canonicalTextSha256("first\rsecond\n"),
+    );
 
     var conflated = valid;
     conflated.documentation_supplement.included_in_code_archive = true;

--- a/conformance/static-machine-v1/release_test.zig
+++ b/conformance/static-machine-v1/release_test.zig
@@ -1,0 +1,210 @@
+const std = @import("std");
+const boundary = @import("boundary");
+const release_sources = @import("boundary_static_machine_release_sources");
+
+const metadata_bytes = @embedFile("release-metadata.json");
+const readme_bytes = release_sources.readme_bytes;
+const static_machine_bytes = release_sources.static_machine_bytes;
+const compatibility_bytes = release_sources.compatibility_bytes;
+const release_hardening_bytes = release_sources.release_hardening_bytes;
+
+const expected_commit = "7f2472100454aa2cd5c62e07db0c1e23eaf46a77";
+const expected_archive_url = "https://github.com/tkersey/boundary/archive/refs/tags/v0.7.0.tar.gz";
+const expected_archive_sha256 = "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a";
+const expected_package_hash = "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_";
+
+const CodeArchive = struct {
+    tag: []const u8,
+    commit: []const u8,
+    url: []const u8,
+    sha256: []const u8,
+    zig_package_hash: []const u8,
+};
+
+const SupplementFile = struct {
+    path: []const u8,
+    sha256: []const u8,
+};
+
+const DocumentationSupplement = struct {
+    included_in_code_archive: bool,
+    identity_kind: []const u8,
+    publication_binding: []const u8,
+    files: []const SupplementFile,
+};
+
+const StaticMachineAbi = struct {
+    version: u32,
+    constructor: []const u8,
+    options: []const u8,
+    state_encoding: []const u8,
+    world_ports: []const u8,
+    compatibility_document: []const u8,
+    supported_contracts: []const []const u8,
+    unsupported_contracts: []const []const u8,
+};
+
+const ReleaseMetadata = struct {
+    schema: []const u8,
+    code_archive: CodeArchive,
+    documentation_supplement: DocumentationSupplement,
+    static_machine_abi: StaticMachineAbi,
+};
+
+const ValidationError = error{
+    InvalidSchema,
+    CodeArchiveIdentityMismatch,
+    DocumentationIdentityConflated,
+    DocumentationIdentityIncomplete,
+    StaticMachineAbiMismatch,
+    SupportMatrixMismatch,
+};
+
+const expected_supported = [_][]const u8{
+    "authentic-boundary-program",
+    "canonical-v1-state",
+    "explicit-world-ports",
+    "acyclic-static-helper-provider-graphs",
+    "admitted-scalar-product-sum-carriers",
+    "closed-authored-failure-set",
+    "bounded-frames-state-and-validation-work",
+    "native-and-wasm32-freestanding",
+};
+
+const expected_unsupported = [_][]const u8{
+    "recursive-helper-provider-graphs",
+    "program-output-or-cleanup-hooks",
+    "mutable-string-list-carriers",
+    "comptime-struct-fields",
+    "non-exhaustive-enums",
+    "unrepresentable-compact-condition-histories",
+    "dynamic-provider-discovery",
+    "runtime-module-loading",
+    "v0-continuation-migration",
+};
+
+const supplement_sources = [_]struct {
+    path: []const u8,
+    bytes: []const u8,
+}{
+    .{ .path = "README.md", .bytes = readme_bytes },
+    .{ .path = "docs/release_hardening.md", .bytes = release_hardening_bytes },
+    .{ .path = "docs/static_machine.md", .bytes = static_machine_bytes },
+    .{ .path = "docs/static_machine_compatibility.md", .bytes = compatibility_bytes },
+};
+
+fn parseMetadata(allocator: std.mem.Allocator) !std.json.Parsed(ReleaseMetadata) {
+    return std.json.parseFromSlice(
+        ReleaseMetadata,
+        allocator,
+        metadata_bytes,
+        .{ .ignore_unknown_fields = false },
+    );
+}
+
+fn expectExactStrings(actual: []const []const u8, expected: []const []const u8) !void {
+    if (actual.len != expected.len) return error.SupportMatrixMismatch;
+    for (actual, expected) |actual_item, expected_item| {
+        if (!std.mem.eql(u8, actual_item, expected_item)) {
+            return error.SupportMatrixMismatch;
+        }
+    }
+}
+
+fn sha256(bytes: []const u8) [64]u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    return std.fmt.bytesToHex(digest, .lower);
+}
+
+fn validateMetadata(metadata: ReleaseMetadata) ValidationError!void {
+    if (!std.mem.eql(u8, metadata.schema, "boundary-static-machine-release/v1")) {
+        return error.InvalidSchema;
+    }
+
+    const archive = metadata.code_archive;
+    if (!std.mem.eql(u8, archive.tag, "v0.7.0") or
+        !std.mem.eql(u8, archive.commit, expected_commit) or
+        !std.mem.eql(u8, archive.url, expected_archive_url) or
+        !std.mem.eql(u8, archive.sha256, expected_archive_sha256) or
+        !std.mem.eql(u8, archive.zig_package_hash, expected_package_hash))
+    {
+        return error.CodeArchiveIdentityMismatch;
+    }
+
+    const supplement = metadata.documentation_supplement;
+    if (supplement.included_in_code_archive or
+        !std.mem.eql(u8, supplement.identity_kind, "ordered-sha256-file-set-v1") or
+        !std.mem.eql(u8, supplement.publication_binding, "reviewed-release-closure-git-commit"))
+    {
+        return error.DocumentationIdentityConflated;
+    }
+    if (supplement.files.len != supplement_sources.len) {
+        return error.DocumentationIdentityIncomplete;
+    }
+    for (supplement.files, supplement_sources) |file, source| {
+        const digest = sha256(source.bytes);
+        if (!std.mem.eql(u8, file.path, source.path) or
+            !std.mem.eql(u8, file.sha256, &digest))
+        {
+            return error.DocumentationIdentityIncomplete;
+        }
+    }
+
+    const abi = metadata.static_machine_abi;
+    if (abi.version != 1 or
+        !std.mem.eql(u8, abi.constructor, "boundary.staticMachine") or
+        !std.mem.eql(u8, abi.options, "boundary.StaticMachineOptions") or
+        !std.mem.eql(u8, abi.state_encoding, "canonical_v1") or
+        !std.mem.eql(u8, abi.world_ports, "explicit") or
+        !std.mem.eql(u8, abi.compatibility_document, "docs/static_machine_compatibility.md"))
+    {
+        return error.StaticMachineAbiMismatch;
+    }
+    try expectExactStrings(abi.supported_contracts, &expected_supported);
+    try expectExactStrings(abi.unsupported_contracts, &expected_unsupported);
+}
+
+fn expectContains(haystack: []const u8, needle: []const u8) !void {
+    try std.testing.expect(std.mem.indexOf(u8, haystack, needle) != null);
+}
+
+test "Boundary v0.7.0 StaticMachine release identity and public surface" {
+    try std.testing.expect(@hasDecl(boundary, "staticMachine"));
+    try std.testing.expect(@hasDecl(boundary, "StaticMachineOptions"));
+
+    var parsed = try parseMetadata(std.testing.allocator);
+    defer parsed.deinit();
+    try validateMetadata(parsed.value);
+
+    try expectContains(readme_bytes, "boundary.program -> boundary.staticMachine -> world.application");
+    try expectContains(readme_bytes, "Program.Session");
+    try expectContains(readme_bytes, "Advanced compatibility: Certified Boundary Modules");
+    try expectContains(static_machine_bytes, "Machine.abi_version == 1");
+    try expectContains(compatibility_bytes, "Fail-closed restrictions");
+    try expectContains(compatibility_bytes, "No transparent migration from a v0 continuation");
+}
+
+test "release metadata falsifiers reject wrong code identity and conflated documentation" {
+    var parsed = try parseMetadata(std.testing.allocator);
+    defer parsed.deinit();
+
+    const valid = parsed.value;
+
+    var wrong_commit = valid;
+    wrong_commit.code_archive.commit = "0000000000000000000000000000000000000000";
+    try std.testing.expectError(error.CodeArchiveIdentityMismatch, validateMetadata(wrong_commit));
+
+    var wrong_hash = valid;
+    wrong_hash.code_archive.zig_package_hash = "boundary-floating-branch";
+    try std.testing.expectError(error.CodeArchiveIdentityMismatch, validateMetadata(wrong_hash));
+
+    var conflated = valid;
+    conflated.documentation_supplement.included_in_code_archive = true;
+    try std.testing.expectError(error.DocumentationIdentityConflated, validateMetadata(conflated));
+
+    var unsupported_claim = valid;
+    unsupported_claim.static_machine_abi.unsupported_contracts =
+        unsupported_claim.static_machine_abi.unsupported_contracts[0..8];
+    try std.testing.expectError(error.SupportMatrixMismatch, validateMetadata(unsupported_claim));
+}

--- a/conformance/static-machine-v1/release_test.zig
+++ b/conformance/static-machine-v1/release_test.zig
@@ -1,8 +1,8 @@
 const boundary = @import("boundary");
+const release_metadata = @import("boundary_static_machine_release_metadata");
 const release_sources = @import("boundary_static_machine_release_sources");
 const std = @import("std");
 
-const metadata_bytes = @embedFile("release-metadata.json");
 const readme_bytes = release_sources.readme_bytes;
 const static_machine_bytes = release_sources.static_machine_bytes;
 const compatibility_bytes = release_sources.compatibility_bytes;
@@ -12,44 +12,7 @@ const expected_commit = "7f2472100454aa2cd5c62e07db0c1e23eaf46a77";
 const expected_archive_url = "https://github.com/tkersey/boundary/archive/refs/tags/v0.7.0.tar.gz";
 const expected_archive_sha256 = "25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a";
 const expected_package_hash = "boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_";
-
-const CodeArchive = struct {
-    tag: []const u8,
-    commit: []const u8,
-    url: []const u8,
-    sha256: []const u8,
-    zig_package_hash: []const u8,
-};
-
-const SupplementFile = struct {
-    path: []const u8,
-    sha256: []const u8,
-};
-
-const DocumentationSupplement = struct {
-    included_in_code_archive: bool,
-    identity_kind: []const u8,
-    publication_binding: []const u8,
-    files: []const SupplementFile,
-};
-
-const StaticMachineAbi = struct {
-    version: u32,
-    constructor: []const u8,
-    options: []const u8,
-    state_encoding: []const u8,
-    world_ports: []const u8,
-    compatibility_document: []const u8,
-    supported_contracts: []const []const u8,
-    unsupported_contracts: []const []const u8,
-};
-
-const ReleaseMetadata = struct {
-    schema: []const u8,
-    code_archive: CodeArchive,
-    documentation_supplement: DocumentationSupplement,
-    static_machine_abi: StaticMachineAbi,
-};
+const expected_zig_version = "0.16.0";
 
 const ValidationError = error{
     InvalidSchema,
@@ -90,11 +53,11 @@ const unsupported_claims = [_]MatrixClaim{
 };
 
 const required_compatibility_claims = [_][]const u8{
-    "`debug_metadata` is diagnostic-only",
-    "`maximum_frames` is an admission bound",
-    "`maximum_state_bytes` is identity-bearing",
-    "World Application v1 accepts only machines whose",
-    "`Machine.EffectRow.after_site_count == 0`",
+    "World Application v1 accepts only machines whose `Machine.EffectRow.after_site_count == 0`; Boundary StaticMachine ABI v1 itself still admits statically known after sites.",
+    "`debug_metadata` is diagnostic-only: changing it does not alter the portable contract fingerprint or canonical state bytes.",
+    "`maximum_frames` is an admission bound: it must cover the reachable helper/provider depth, but increasing an already sufficient value does not alter the portable contract fingerprint or canonical state bytes.",
+    "`maximum_state_bytes` is identity-bearing: changing it alters the machine contract because it bounds canonical state images.",
+    "The focused release gate selects only registered `static_machine_*` compile-fail fixtures; it is representative rather than exhaustive, while the aggregate `compile-fail` gate retains the complete repository rejection corpus.",
 };
 
 const supplement_sources = [_]struct {
@@ -106,15 +69,6 @@ const supplement_sources = [_]struct {
     .{ .path = "docs/static_machine.md", .bytes = static_machine_bytes },
     .{ .path = "docs/static_machine_compatibility.md", .bytes = compatibility_bytes },
 };
-
-fn parseMetadata(allocator: std.mem.Allocator) !std.json.Parsed(ReleaseMetadata) {
-    return std.json.parseFromSlice(
-        ReleaseMetadata,
-        allocator,
-        metadata_bytes,
-        .{ .ignore_unknown_fields = false },
-    );
-}
 
 fn sha256(bytes: []const u8) [64]u8 {
     var digest: [32]u8 = @splat(0);
@@ -144,7 +98,7 @@ fn validateCompatibilityDocument(document: []const u8) ValidationError!void {
     }
 }
 
-fn validateMetadata(metadata: ReleaseMetadata) ValidationError!void {
+fn validateMetadata(metadata: release_metadata.ReleaseMetadata) ValidationError!void {
     if (!std.mem.eql(u8, metadata.schema, "boundary-static-machine-release/v1")) {
         return error.InvalidSchema;
     }
@@ -154,7 +108,8 @@ fn validateMetadata(metadata: ReleaseMetadata) ValidationError!void {
         !std.mem.eql(u8, archive.commit, expected_commit) or
         !std.mem.eql(u8, archive.url, expected_archive_url) or
         !std.mem.eql(u8, archive.sha256, expected_archive_sha256) or
-        !std.mem.eql(u8, archive.zig_package_hash, expected_package_hash))
+        !std.mem.eql(u8, archive.zig_package_hash, expected_package_hash) or
+        !std.mem.eql(u8, archive.zig_version, expected_zig_version))
     {
         return error.CodeArchiveIdentityMismatch;
     }
@@ -250,7 +205,7 @@ test "Boundary v0.7.0 StaticMachine release identity and public surface" {
     try std.testing.expect(@hasDecl(boundary, "staticMachine"));
     try std.testing.expect(@hasDecl(boundary, "StaticMachineOptions"));
 
-    var parsed = try parseMetadata(std.testing.allocator);
+    var parsed = try release_metadata.parse(std.testing.allocator);
     defer parsed.deinit();
     try validateMetadata(parsed.value);
 
@@ -282,7 +237,7 @@ test "Boundary v0.7.0 StaticMachine release identity and public surface" {
 }
 
 test "release metadata falsifiers reject wrong code identity and conflated documentation" {
-    var parsed = try parseMetadata(std.testing.allocator);
+    var parsed = try release_metadata.parse(std.testing.allocator);
     defer parsed.deinit();
 
     const valid = parsed.value;
@@ -306,6 +261,12 @@ test "release metadata falsifiers reject wrong code identity and conflated docum
 
     try std.testing.expectError(
         error.CompatibilityClaimMissing,
-        validateCompatibilityDocument("Fail-closed restrictions without owner-bound compatibility claims."),
+        validateCompatibilityDocument(
+            "World Application v1 accepts only machines whose after count is zero. " ++
+                "Boundary StaticMachine ABI v1 rejects after sites. " ++
+                "`debug_metadata` is not identity-bearing. " ++
+                "`maximum_frames` is an admission bound. " ++
+                "`maximum_state_bytes` is identity-bearing.",
+        ),
     );
 }

--- a/conformance/static-machine-v1/release_test.zig
+++ b/conformance/static-machine-v1/release_test.zig
@@ -22,6 +22,7 @@ const ValidationError = error{
     StaticMachineAbiMismatch,
     SupportMatrixMismatch,
     CompatibilityClaimMissing,
+    PrimaryWorldExampleMismatch,
 };
 
 const MatrixClaim = struct {
@@ -60,6 +61,13 @@ const required_compatibility_claims = [_][]const u8{
     "The focused release gate selects only registered `static_machine_*` compile-fail fixtures; it is representative rather than exhaustive, while the aggregate `compile-fail` gate retains the complete repository rejection corpus.",
 };
 
+const primary_world_example_claims = [_][]const u8{
+    "return 42;",
+    ".op_name = \"authored\", .mode = .transform, .payload_codec = .unit, .resume_codec = .i32, .has_after = false",
+    "The supported portable path reuses the same validated program type:",
+    "`boundary.staticMachine` is the World Comptime v1 deployment surface.",
+};
+
 const supplement_sources = [_]struct {
     path: []const u8,
     bytes: []const u8,
@@ -94,6 +102,14 @@ fn validateCompatibilityDocument(document: []const u8) ValidationError!void {
     for (&required_compatibility_claims) |claim| {
         if (std.mem.find(u8, document, claim) == null) {
             return error.CompatibilityClaimMissing;
+        }
+    }
+}
+
+fn validatePrimaryWorldExample(document: []const u8) ValidationError!void {
+    for (&primary_world_example_claims) |claim| {
+        if (std.mem.find(u8, document, claim) == null) {
+            return error.PrimaryWorldExampleMismatch;
         }
     }
 }
@@ -146,6 +162,7 @@ fn validateMetadata(metadata: release_metadata.ReleaseMetadata) ValidationError!
     try validateMatrixClaims(abi.supported_contracts, &supported_claims, compatibility_bytes);
     try validateMatrixClaims(abi.unsupported_contracts, &unsupported_claims, compatibility_bytes);
     try validateCompatibilityDocument(compatibility_bytes);
+    try validatePrimaryWorldExample(readme_bytes);
 }
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
@@ -267,6 +284,16 @@ test "release metadata falsifiers reject wrong code identity and conflated docum
                 "`debug_metadata` is not identity-bearing. " ++
                 "`maximum_frames` is an admission bound. " ++
                 "`maximum_state_bytes` is identity-bearing.",
+        ),
+    );
+
+    try std.testing.expectError(
+        error.PrimaryWorldExampleMismatch,
+        validatePrimaryWorldExample(
+            "return 41; " ++
+                ".op_name = \"authored\", .mode = .transform, .payload_codec = .unit, .resume_codec = .i32, .has_after = true " ++
+                "The supported portable path reuses the same validated program type: " ++
+                "`boundary.staticMachine` is the World Comptime v1 deployment surface.",
         ),
     );
 }

--- a/conformance/static-machine-v1/release_test.zig
+++ b/conformance/static-machine-v1/release_test.zig
@@ -1,6 +1,6 @@
-const std = @import("std");
 const boundary = @import("boundary");
 const release_sources = @import("boundary_static_machine_release_sources");
+const std = @import("std");
 
 const metadata_bytes = @embedFile("release-metadata.json");
 const readme_bytes = release_sources.readme_bytes;
@@ -55,32 +55,46 @@ const ValidationError = error{
     InvalidSchema,
     CodeArchiveIdentityMismatch,
     DocumentationIdentityConflated,
-    DocumentationIdentityIncomplete,
+    DocumentationIdentityInvalid,
     StaticMachineAbiMismatch,
     SupportMatrixMismatch,
+    CompatibilityClaimMissing,
 };
 
-const expected_supported = [_][]const u8{
-    "authentic-boundary-program",
-    "canonical-v1-state",
-    "explicit-world-ports",
-    "acyclic-static-helper-provider-graphs",
-    "admitted-scalar-product-sum-carriers",
-    "closed-authored-failure-set",
-    "bounded-frames-state-and-validation-work",
-    "native-and-wasm32-freestanding",
+const MatrixClaim = struct {
+    identifier: []const u8,
+    marker: []const u8,
 };
 
-const expected_unsupported = [_][]const u8{
-    "recursive-helper-provider-graphs",
-    "program-output-or-cleanup-hooks",
-    "mutable-string-list-carriers",
-    "comptime-struct-fields",
-    "non-exhaustive-enums",
-    "unrepresentable-compact-condition-histories",
-    "dynamic-provider-discovery",
-    "runtime-module-loading",
-    "v0-continuation-migration",
+const supported_claims = [_]MatrixClaim{
+    .{ .identifier = "authentic-boundary-program", .marker = "`authentic-boundary-program`: the input type is returned by `boundary.program`." },
+    .{ .identifier = "canonical-v1-state", .marker = "`canonical-v1-state`: state bytes use `.canonical_v1`." },
+    .{ .identifier = "explicit-world-ports", .marker = "`explicit-world-ports`: residual world ports use `.explicit`." },
+    .{ .identifier = "acyclic-static-helper-provider-graphs", .marker = "`acyclic-static-helper-provider-graphs`: helper and nested-provider frame graphs are static and acyclic." },
+    .{ .identifier = "admitted-scalar-product-sum-carriers", .marker = "`admitted-scalar-product-sum-carriers`: admitted scalar, product, and sum schemas retain their exact logical identities." },
+    .{ .identifier = "closed-authored-failure-set", .marker = "`closed-authored-failure-set`: `Body.Error` is closed and excludes reserved operational errors." },
+    .{ .identifier = "bounded-frames-state-and-validation-work", .marker = "`bounded-frames-state-and-validation-work`: frame admission, state bytes, and generated validation work are bounded." },
+    .{ .identifier = "native-and-wasm32-freestanding", .marker = "`native-and-wasm32-freestanding`: native and `wasm32-freestanding` compile gates are required." },
+};
+
+const unsupported_claims = [_]MatrixClaim{
+    .{ .identifier = "recursive-helper-provider-graphs", .marker = "`recursive-helper-provider-graphs`: rejected by StaticMachine v1." },
+    .{ .identifier = "program-output-or-cleanup-hooks", .marker = "`program-output-or-cleanup-hooks`: rejected by StaticMachine v1." },
+    .{ .identifier = "mutable-string-list-carriers", .marker = "`mutable-string-list-carriers`: rejected by StaticMachine v1." },
+    .{ .identifier = "comptime-struct-fields", .marker = "`comptime-struct-fields`: rejected by StaticMachine v1." },
+    .{ .identifier = "non-exhaustive-enums", .marker = "`non-exhaustive-enums`: rejected by StaticMachine v1." },
+    .{ .identifier = "unrepresentable-compact-condition-histories", .marker = "`unrepresentable-compact-condition-histories`: rejected by StaticMachine v1." },
+    .{ .identifier = "dynamic-provider-discovery", .marker = "`dynamic-provider-discovery`: outside StaticMachine v1." },
+    .{ .identifier = "runtime-module-loading", .marker = "`runtime-module-loading`: outside StaticMachine v1." },
+    .{ .identifier = "v0-continuation-migration", .marker = "`v0-continuation-migration`: no transparent migration is supported." },
+};
+
+const required_compatibility_claims = [_][]const u8{
+    "`debug_metadata` is diagnostic-only",
+    "`maximum_frames` is an admission bound",
+    "`maximum_state_bytes` is identity-bearing",
+    "World Application v1 accepts only machines whose",
+    "`Machine.EffectRow.after_site_count == 0`",
 };
 
 const supplement_sources = [_]struct {
@@ -102,19 +116,32 @@ fn parseMetadata(allocator: std.mem.Allocator) !std.json.Parsed(ReleaseMetadata)
     );
 }
 
-fn expectExactStrings(actual: []const []const u8, expected: []const []const u8) !void {
-    if (actual.len != expected.len) return error.SupportMatrixMismatch;
-    for (actual, expected) |actual_item, expected_item| {
-        if (!std.mem.eql(u8, actual_item, expected_item)) {
-            return error.SupportMatrixMismatch;
+fn sha256(bytes: []const u8) [64]u8 {
+    var digest: [32]u8 = @splat(0);
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    return std.fmt.bytesToHex(digest, .lower);
+}
+
+fn validateMatrixClaims(
+    actual: []const []const u8,
+    claims: []const MatrixClaim,
+    document: []const u8,
+) ValidationError!void {
+    if (actual.len != claims.len) return error.SupportMatrixMismatch;
+    for (actual, claims) |actual_id, claim| {
+        if (!std.mem.eql(u8, actual_id, claim.identifier)) return error.SupportMatrixMismatch;
+        if (std.mem.find(u8, document, claim.marker) == null) {
+            return error.CompatibilityClaimMissing;
         }
     }
 }
 
-fn sha256(bytes: []const u8) [64]u8 {
-    var digest: [32]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
-    return std.fmt.bytesToHex(digest, .lower);
+fn validateCompatibilityDocument(document: []const u8) ValidationError!void {
+    for (&required_compatibility_claims) |claim| {
+        if (std.mem.find(u8, document, claim) == null) {
+            return error.CompatibilityClaimMissing;
+        }
+    }
 }
 
 fn validateMetadata(metadata: ReleaseMetadata) ValidationError!void {
@@ -140,14 +167,14 @@ fn validateMetadata(metadata: ReleaseMetadata) ValidationError!void {
         return error.DocumentationIdentityConflated;
     }
     if (supplement.files.len != supplement_sources.len) {
-        return error.DocumentationIdentityIncomplete;
+        return error.DocumentationIdentityInvalid;
     }
     for (supplement.files, supplement_sources) |file, source| {
         const digest = sha256(source.bytes);
         if (!std.mem.eql(u8, file.path, source.path) or
             !std.mem.eql(u8, file.sha256, &digest))
         {
-            return error.DocumentationIdentityIncomplete;
+            return error.DocumentationIdentityInvalid;
         }
     }
 
@@ -161,13 +188,63 @@ fn validateMetadata(metadata: ReleaseMetadata) ValidationError!void {
     {
         return error.StaticMachineAbiMismatch;
     }
-    try expectExactStrings(abi.supported_contracts, &expected_supported);
-    try expectExactStrings(abi.unsupported_contracts, &expected_unsupported);
+    try validateMatrixClaims(abi.supported_contracts, &supported_claims, compatibility_bytes);
+    try validateMatrixClaims(abi.unsupported_contracts, &unsupported_claims, compatibility_bytes);
+    try validateCompatibilityDocument(compatibility_bytes);
 }
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {
-    try std.testing.expect(std.mem.indexOf(u8, haystack, needle) != null);
+    try std.testing.expect(std.mem.find(u8, haystack, needle) != null);
 }
+
+fn releaseUnitPlan() boundary.ir.ProgramPlan {
+    const root = boundary.ir.builder.function(0);
+    const functions = [_]boundary.ir.plan.Function{.{
+        .symbol_name = "run",
+        .value_codec = .unit,
+        .result_codec = .unit,
+        .parameter_count = 0,
+        .first_requirement = 0,
+        .requirement_count = 0,
+        .first_output = 0,
+        .output_count = 0,
+        .first_local = 0,
+        .local_count = 0,
+        .first_block = 0,
+        .entry_block = 0,
+        .block_count = 1,
+        .first_instruction = 0,
+        .instruction_count = 0,
+    }};
+    const blocks = [_]boundary.ir.plan.Block{.{
+        .first_instruction = 0,
+        .instruction_count = 0,
+        .terminator_index = 0,
+    }};
+    const terminators = [_]boundary.ir.plan.Terminator{.{ .kind = .return_unit }};
+    return boundary.ir.builder.finish(.{
+        .label = "boundary-release-owner-binding",
+        .ir_hash = 1,
+        .entry = root,
+        .functions = &functions,
+        .requirements = &.{},
+        .ops = &.{},
+        .outputs = &.{},
+        .locals = &.{},
+        .blocks = &blocks,
+        .terminators = &terminators,
+        .instructions = &.{},
+    }) catch |err| @compileError(@errorName(err));
+}
+
+const ReleaseProgram = boundary.program("boundary-release-owner-binding", struct {}, struct {
+    /// Authentic ProgramPlan compiled into the release ABI witness.
+    pub const compiled_plan = releaseUnitPlan();
+});
+const ReleaseMachine = boundary.staticMachine(ReleaseProgram, .{});
+const ReleaseDebugMachine = boundary.staticMachine(ReleaseProgram, .{ .debug_metadata = true });
+const ReleaseExpandedFramesMachine = boundary.staticMachine(ReleaseProgram, .{ .maximum_frames = 65 });
+const ReleaseExpandedStateMachine = boundary.staticMachine(ReleaseProgram, .{ .maximum_state_bytes = (1 << 20) + 1 });
 
 test "Boundary v0.7.0 StaticMachine release identity and public surface" {
     try std.testing.expect(@hasDecl(boundary, "staticMachine"));
@@ -176,6 +253,25 @@ test "Boundary v0.7.0 StaticMachine release identity and public surface" {
     var parsed = try parseMetadata(std.testing.allocator);
     defer parsed.deinit();
     try validateMetadata(parsed.value);
+
+    try std.testing.expectEqual(parsed.value.static_machine_abi.version, ReleaseMachine.abi_version);
+    try std.testing.expectEqual(ReleaseMachine.abi_version, ReleaseMachine.Manifest.abi);
+    try std.testing.expect(ReleaseMachine.Manifest.state_is_canonical_v1);
+    try std.testing.expect(ReleaseMachine.Manifest.ports_are_explicit);
+    try std.testing.expect(!ReleaseMachine.Manifest.includes_debug_metadata);
+    try std.testing.expect(ReleaseDebugMachine.Manifest.includes_debug_metadata);
+    try std.testing.expectEqual(
+        ReleaseMachine.Manifest.machine_contract_fingerprint,
+        ReleaseDebugMachine.Manifest.machine_contract_fingerprint,
+    );
+    try std.testing.expectEqual(
+        ReleaseMachine.Manifest.machine_contract_fingerprint,
+        ReleaseExpandedFramesMachine.Manifest.machine_contract_fingerprint,
+    );
+    try std.testing.expect(
+        ReleaseMachine.Manifest.machine_contract_fingerprint !=
+            ReleaseExpandedStateMachine.Manifest.machine_contract_fingerprint,
+    );
 
     try expectContains(readme_bytes, "boundary.program -> boundary.staticMachine -> world.application");
     try expectContains(readme_bytes, "Program.Session");
@@ -207,4 +303,9 @@ test "release metadata falsifiers reject wrong code identity and conflated docum
     unsupported_claim.static_machine_abi.unsupported_contracts =
         unsupported_claim.static_machine_abi.unsupported_contracts[0..8];
     try std.testing.expectError(error.SupportMatrixMismatch, validateMetadata(unsupported_claim));
+
+    try std.testing.expectError(
+        error.CompatibilityClaimMissing,
+        validateCompatibilityDocument("Fail-closed restrictions without owner-bound compatibility claims."),
+    );
 }

--- a/conformance/static-machine-v1/release_test.zig
+++ b/conformance/static-machine-v1/release_test.zig
@@ -266,6 +266,7 @@ test "release metadata falsifiers reject wrong code identity and conflated docum
     defer parsed.deinit();
 
     const valid = parsed.value;
+    try validateMetadata(valid);
 
     var wrong_commit = valid;
     wrong_commit.code_archive.commit = "0000000000000000000000000000000000000000";

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -43,9 +43,13 @@ publication receipt separately binds the reviewed release-closure commit. The
 focused release gate checks that receipt and its owner-derived ABI and matrix
 claims. The materialized-archive gate first admits the receipt through the
 fixed v0.7.0 identity oracle, then accepts only the typed
-`-Dboundary-release-archive` input, snapshots it in the build cache, recomputes
-its SHA-256, checks Zig `0.16.0`, and asks that toolchain to recompute the
-package hash from the same snapshot without requiring network access.
+`-Dboundary-release-archive` input. Its host verifier always runs against that
+original operator-selected path, recomputes the current bytes' SHA-256, checks
+Zig `0.16.0`, and asks that toolchain to recompute the package hash from the
+same retained bytes without requiring network access. A functional cache
+falsifier repeats the gate after a same-size byte substitution with an aged
+mtime restored; the second invocation must reject the current bytes rather than
+reuse a stale build-cache snapshot.
 
 ## File classification
 

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -10,18 +10,22 @@ Run these before publishing a branch:
 
 ```sh
 zig version
-zig fmt --check build.zig src examples test bench
+zig fmt --check build.zig src examples test bench conformance
 git diff --check
 zig build check-boundary-static-machine-release
 zig build check-boundary-static-machine-release-falsifiers
+zig build check-boundary-static-machine-release-archive -- /path/to/boundary-v0.7.0.tar.gz
+zig build check-boundary-static-machine-release-archive-falsifiers
 zig build --summary all
 zig build test --summary all
 zig build lint -- --max-warnings 0
 ```
 
-`zig build lint` reads `repo_zig_paths.txt` and also checks that every `.zig`
-file under `src`, `examples`, `test`, and `bench` appears in that manifest. Add
-new Zig files to the manifest in the same patch that adds the file.
+`zig build lint` checks `build.zig` and every Zig source under `src`,
+`examples`, `test`, `bench`, and `conformance`. Its path-coverage guard also
+checks that every `.zig` file under `src`, `examples`, `test`, and `bench`
+appears in `repo_zig_paths.txt`. Add new maintained source files to that
+manifest in the same patch that adds the file.
 
 `build.zig.zon` packages the maintained source, docs, examples, tests,
 benchmarks, and manifest. Keep package paths aligned with any new top-level
@@ -33,7 +37,10 @@ bytes from the tagged archive. The checked receipt at
 `conformance/static-machine-v1/release-metadata.json` binds the tag target,
 archive URL, archive SHA-256, Zig package hash, public StaticMachine ABI, and an
 ordered digest set for the supplement. A publication receipt separately binds
-the reviewed release-closure commit.
+the reviewed release-closure commit. The focused release gate checks that
+receipt and its owner-derived ABI and matrix claims. The materialized-archive
+gate consumes a local archive, recomputes its SHA-256, and asks the pinned Zig
+toolchain to recompute its package hash without requiring network access.
 
 ## File classification
 

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -36,13 +36,16 @@ added after that tag is a distinct supplement and must not be described as
 bytes from the tagged archive. The checked receipt at
 `conformance/static-machine-v1/release-metadata.json` binds the tag target,
 archive URL, archive SHA-256, Zig package hash, public StaticMachine ABI, and an
-ordered digest set for the supplement. A publication receipt separately binds
-the reviewed release-closure commit. The focused release gate checks that
-receipt and its owner-derived ABI and matrix claims. The materialized-archive
-gate accepts only the typed `-Dboundary-release-archive` input, snapshots it in
-the build cache, recomputes its SHA-256, checks Zig `0.16.0`, and asks that
-toolchain to recompute the package hash from the same snapshot without
-requiring network access.
+ordered canonical-text digest set for the supplement. Canonical text maps LF
+and CRLF materializations to LF before hashing and rejects bare carriage
+returns, so checkout configuration cannot alter the supplement identity. A
+publication receipt separately binds the reviewed release-closure commit. The
+focused release gate checks that receipt and its owner-derived ABI and matrix
+claims. The materialized-archive gate first admits the receipt through the
+fixed v0.7.0 identity oracle, then accepts only the typed
+`-Dboundary-release-archive` input, snapshots it in the build cache, recomputes
+its SHA-256, checks Zig `0.16.0`, and asks that toolchain to recompute the
+package hash from the same snapshot without requiring network access.
 
 ## File classification
 

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -14,7 +14,7 @@ zig fmt --check build.zig src examples test bench conformance
 git diff --check
 zig build check-boundary-static-machine-release
 zig build check-boundary-static-machine-release-falsifiers
-zig build check-boundary-static-machine-release-archive -- /path/to/boundary-v0.7.0.tar.gz
+zig build check-boundary-static-machine-release-archive -Dboundary-release-archive=/path/to/boundary-v0.7.0.tar.gz
 zig build check-boundary-static-machine-release-archive-falsifiers
 zig build --summary all
 zig build test --summary all
@@ -39,8 +39,10 @@ archive URL, archive SHA-256, Zig package hash, public StaticMachine ABI, and an
 ordered digest set for the supplement. A publication receipt separately binds
 the reviewed release-closure commit. The focused release gate checks that
 receipt and its owner-derived ABI and matrix claims. The materialized-archive
-gate consumes a local archive, recomputes its SHA-256, and asks the pinned Zig
-toolchain to recompute its package hash without requiring network access.
+gate accepts only the typed `-Dboundary-release-archive` input, snapshots it in
+the build cache, recomputes its SHA-256, checks Zig `0.16.0`, and asks that
+toolchain to recompute the package hash from the same snapshot without
+requiring network access.
 
 ## File classification
 

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -55,9 +55,12 @@ than reuse a stale build-cache snapshot.
 The `zig build` command requires the source package's declared build
 dependencies to have been materialized in the selected Zig cache. For
 network-free revalidation from a materialized Boundary source package, use
-`release_archive_check_offline.sh`; it compiles only the archive checker and
-fixed release metadata with isolated local and global caches, so it does not
-resolve `build.zig.zon` dependencies.
+`release_archive_check_offline.sh`; it builds a small process-group owner and
+the archive checker against fixed release metadata with isolated local and
+global caches, so it does not resolve `build.zig.zon` dependencies. The wrapper
+admits proof work only after verifying actual SIGINT delivery, terminates the
+verifier-owned process group before removing its proof root, and reports
+success only after the checker writes the canonical completion receipt.
 
 ## File classification
 

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -12,6 +12,8 @@ Run these before publishing a branch:
 zig version
 zig fmt --check build.zig src examples test bench
 git diff --check
+zig build check-boundary-static-machine-release
+zig build check-boundary-static-machine-release-falsifiers
 zig build --summary all
 zig build test --summary all
 zig build lint -- --max-warnings 0
@@ -25,6 +27,14 @@ new Zig files to the manifest in the same patch that adds the file.
 benchmarks, and manifest. Keep package paths aligned with any new top-level
 surface that users need in source distributions.
 
+The Boundary v0.7.0 code archive is immutable. Release-closure documentation
+added after that tag is a distinct supplement and must not be described as
+bytes from the tagged archive. The checked receipt at
+`conformance/static-machine-v1/release-metadata.json` binds the tag target,
+archive URL, archive SHA-256, Zig package hash, public StaticMachine ABI, and an
+ordered digest set for the supplement. A publication receipt separately binds
+the reviewed release-closure commit.
+
 ## File classification
 
 Public:
@@ -33,7 +43,8 @@ Public:
 - `src/boundary_shared.zig`
 - `src/effect/root.zig`
 - `src/ir_api.zig`
-- `src/program_api.zig`
+- `src/program_api.zig` through the public `boundary.program`,
+  `boundary.staticMachine`, and `boundary.StaticMachineOptions` aliases
 - `src/lowered_machine.zig` through the public `boundary.Runtime` alias
 
 Public-adjacent:
@@ -96,6 +107,10 @@ Tests:
   `docs/program_plan.md`
 - Custom effect authoring direction:
   `docs/custom_effect_authoring.md`
+- StaticMachine ABI v1 contract:
+  `docs/static_machine.md`
+- StaticMachine v1 support and compatibility matrix:
+  `docs/static_machine_compatibility.md`
 - Release/package/lint discipline and file classification:
   this document
 
@@ -123,5 +138,6 @@ Non-goals for release hardening:
 - Do not expose Artifact, VM, compile, parser, `effect.Define`, or `effect.ops`
   as public APIs.
 - Do not widen `ProgramValue`.
+- Do not widen StaticMachine v1 support as part of release hardening.
 - Do not remove compatibility built-ins until plan-native examples and tests are
   sufficient replacement evidence.

--- a/docs/release_hardening.md
+++ b/docs/release_hardening.md
@@ -15,6 +15,7 @@ git diff --check
 zig build check-boundary-static-machine-release
 zig build check-boundary-static-machine-release-falsifiers
 zig build check-boundary-static-machine-release-archive -Dboundary-release-archive=/path/to/boundary-v0.7.0.tar.gz
+sh conformance/static-machine-v1/release_archive_check_offline.sh zig /path/to/boundary-v0.7.0.tar.gz
 zig build check-boundary-static-machine-release-archive-falsifiers
 zig build --summary all
 zig build test --summary all
@@ -43,13 +44,20 @@ publication receipt separately binds the reviewed release-closure commit. The
 focused release gate checks that receipt and its owner-derived ABI and matrix
 claims. The materialized-archive gate first admits the receipt through the
 fixed v0.7.0 identity oracle, then accepts only the typed
-`-Dboundary-release-archive` input. Its host verifier always runs against that
-original operator-selected path, recomputes the current bytes' SHA-256, checks
-Zig `0.16.0`, and asks that toolchain to recompute the package hash from the
-same retained bytes without requiring network access. A functional cache
-falsifier repeats the gate after a same-size byte substitution with an aged
-mtime restored; the second invocation must reject the current bytes rather than
-reuse a stale build-cache snapshot.
+`-Dboundary-release-archive` input. Its host verifier always reads the original
+operator-selected path, recomputes the current bytes' SHA-256, writes those
+admitted bytes to a private snapshot, checks Zig `0.16.0`, and asks that
+toolchain to recompute the package hash from that same snapshot. A functional
+cache falsifier repeats the gate after a same-size byte substitution with an
+aged mtime restored; the second invocation must reject the current bytes rather
+than reuse a stale build-cache snapshot.
+
+The `zig build` command requires the source package's declared build
+dependencies to have been materialized in the selected Zig cache. For
+network-free revalidation from a materialized Boundary source package, use
+`release_archive_check_offline.sh`; it compiles only the archive checker and
+fixed release metadata with isolated local and global caches, so it does not
+resolve `build.zig.zon` dependencies.
 
 ## File classification
 

--- a/docs/static_machine.md
+++ b/docs/static_machine.md
@@ -4,6 +4,10 @@
 defunctionalized reducer for a type returned by `boundary.program`. It is the
 Boundary-to-World compile-time seam for World Comptime v1.
 
+`boundary.staticMachine` and `boundary.StaticMachineOptions` are supported
+public package-root declarations in Boundary v0.7.0. The ABI version exposed by
+every generated machine is `Machine.abi_version == 1`.
+
 ```zig
 const Program = boundary.program("example", Handlers, Body);
 const Machine = boundary.staticMachine(Program, .{
@@ -232,3 +236,9 @@ site sets for a legacy namespace-collision plan. Static sites retain the exact
 matching legacy fingerprint as provenance, even when corrected reachability
 changes their dense ordinal. World v1 must close `Machine.EffectRow`; it must
 not infer the static residual row from `Program.protocol`.
+
+The release-level support matrix is maintained in
+[static_machine_compatibility.md](static_machine_compatibility.md). The
+machine-readable Boundary v0.7.0 code identity and documentation-supplement
+identity are checked from
+`conformance/static-machine-v1/release-metadata.json`.

--- a/docs/static_machine_compatibility.md
+++ b/docs/static_machine_compatibility.md
@@ -1,0 +1,109 @@
+# Boundary StaticMachine ABI v1 compatibility matrix
+
+This document is the release matrix for the supported
+`boundary.staticMachine` surface in Boundary v0.7.0. It describes the current
+admitted domain; it does not add execution semantics.
+
+## Release identity
+
+The reviewed Boundary code package is the immutable `v0.7.0` archive. Its tag
+target, archive URL, archive SHA-256, and Zig package hash are recorded in
+`conformance/static-machine-v1/release-metadata.json`.
+
+This matrix, the primary README changes, and later release-hardening
+documentation form a separate documentation supplement. The supplement is not
+part of the fixed `v0.7.0` code archive. Its ordered file digests are recorded
+in the same metadata, while the publication receipt binds the reviewed
+release-closure commit.
+
+## Public ABI
+
+| Surface | ABI v1 contract |
+| --- | --- |
+| Constructor | `boundary.staticMachine(Program, options)` |
+| Options | `boundary.StaticMachineOptions` |
+| Program authority | an authentic type returned by `boundary.program` |
+| ABI identity | `Machine.abi_version == 1` |
+| Portable state | `initialState`, `cloneState`, `encodeState`, `decodeState`, `validateState`, `deinitState` |
+| Reduction | `reduce`, `current`, `resume`, `resumeAfter`, `returnNow` |
+| Static declarations | `InitialArgs`, `State`, `Result`, `EffectRow`, `Manifest`, authored `Failure`, closed `Error` |
+| State encoding | `.canonical_v1` |
+| Residual ports | `.explicit` |
+| Semantic parity authority | `Program.Session` on the admitted StaticMachine domain |
+
+World v1 closes `Machine.EffectRow`. It must not infer the residual static row
+from `Program.protocol`.
+
+## Supported domain
+
+| Area | StaticMachine ABI v1 |
+| --- | --- |
+| Program source | validated comptime `ProgramPlan` owned by `boundary.program` |
+| Scalar values | admitted ProgramPlan scalar carriers |
+| Structured values | admitted product and sum schemas with exact `Body.value_schema_types` |
+| String lists | immutable `[]const []const u8` |
+| Enums | exhaustive enums, bound by ordered names and explicit discriminants |
+| `usize` | canonical unsigned 32-bit semantic domain |
+| Helpers/providers | statically known, acyclic helper and nested-provider frame graphs |
+| Effects | statically known operation and after sites; residual ports remain explicit |
+| Control | control paths exactly representable by the compact condition authority |
+| Failure | closed `Body.Error`, excluding reserved operational error names |
+| Limits | positive `maximum_frames`; positive `maximum_state_bytes` within `u32`; generated validation ceilings |
+| Target | native Zig and `wasm32-freestanding` compile gates |
+
+## Fail-closed restrictions
+
+Construction rejects these shapes at comptime:
+
+- a type not returned by `boundary.program`;
+- recursive helper or nested-provider frame graphs;
+- output collection, result cleanup, or output cleanup hooks;
+- mutable `[][]const u8`, comptime struct fields, non-exhaustive enums, or
+  `noreturn` schema carriers;
+- a non-closed `Body.Error` or authored use of reserved operational errors;
+- zero or insufficient `maximum_frames`;
+- zero or greater-than-`u32` `maximum_state_bytes`;
+- control and predicate histories the compact v1 state carrier cannot validate
+  exactly;
+- after-continuation chains that do not close over their static input, output,
+  and function-result types;
+- programs exceeding the fixed control-path, scratch-memory, or validation-work
+  ceilings.
+
+There is no fallback to a loaded module, dynamic provider discovery, or runtime
+module loading. Broader programs remain usable through `Program.Session`; they
+are outside StaticMachine ABI v1 until a later reviewed ABI expands the portable
+representation.
+
+## Compatibility rules
+
+- Contract-compatible machines exchange canonical state bytes, not live `State`
+  pointers.
+- Live `State` handles remain machine-branded and single-owner.
+- Machine identity binds the admitted ProgramPlan, structured carriers, effect
+  row, options, limits, and corrected StaticMachine reachability.
+- Nominal type renames preserve compatibility only when admitted carrier
+  semantics are unchanged.
+- Logical field, enum discriminant, effect-site, option, or resource-limit
+  changes alter the machine contract.
+- `Program.Session` retains native-width `usize`, dynamic completion behavior,
+  and its legacy reachability interpretation. StaticMachine v1 does not silently
+  inherit those behaviors.
+- No transparent migration from a v0 continuation or loaded module into a
+  StaticMachine v1 state is supported.
+
+## Proof gates
+
+```sh
+zig build check-boundary-static-machine
+zig build check-boundary-static-machine-parity
+zig build check-boundary-static-machine-wasm32
+zig build check-boundary-static-machine-release
+zig build check-boundary-static-machine-release-falsifiers
+zig build check --summary all
+```
+
+The release verifier checks the public declarations, exact code identity,
+documentation-supplement digests, required matrix claims, and negative
+falsifiers. The existing StaticMachine, parity, wasm32, and aggregate gates
+remain the semantic proof.

--- a/docs/static_machine_compatibility.md
+++ b/docs/static_machine_compatibility.md
@@ -32,7 +32,9 @@ release-closure commit.
 | Semantic parity authority | `Program.Session` on the admitted StaticMachine domain |
 
 World v1 closes `Machine.EffectRow`. It must not infer the residual static row
-from `Program.protocol`.
+from `Program.protocol`. World Application v1 accepts only machines whose
+`Machine.EffectRow.after_site_count == 0`; Boundary StaticMachine ABI v1 itself
+still admits statically known after sites.
 
 ## Supported domain
 
@@ -81,16 +83,52 @@ representation.
   pointers.
 - Live `State` handles remain machine-branded and single-owner.
 - Machine identity binds the admitted ProgramPlan, structured carriers, effect
-  row, options, limits, and corrected StaticMachine reachability.
+  row, `maximum_state_bytes`, and generated validation and reachability
+  authorities.
 - Nominal type renames preserve compatibility only when admitted carrier
   semantics are unchanged.
-- Logical field, enum discriminant, effect-site, option, or resource-limit
-  changes alter the machine contract.
+- Logical field, enum discriminant, effect-site, or identity-bearing limit
+  changes alter the machine contract. `maximum_state_bytes` is identity-bearing
+  because it bounds canonical state images.
+- `debug_metadata` is diagnostic-only: changing it does not alter the portable
+  contract fingerprint or canonical state bytes.
+- `maximum_frames` is an admission bound: it must cover the reachable
+  helper/provider depth, but increasing an already sufficient value does not
+  alter the portable contract fingerprint or canonical state bytes.
 - `Program.Session` retains native-width `usize`, dynamic completion behavior,
   and its legacy reachability interpretation. StaticMachine v1 does not silently
   inherit those behaviors.
 - No transparent migration from a v0 continuation or loaded module into a
   StaticMachine v1 state is supported.
+
+## Machine-checked release claims
+
+The focused release verifier binds the metadata identifiers below to these
+exact compatibility claims and to a generated `boundary.staticMachine` ABI
+witness.
+
+Supported:
+
+- `authentic-boundary-program`: the input type is returned by `boundary.program`.
+- `canonical-v1-state`: state bytes use `.canonical_v1`.
+- `explicit-world-ports`: residual world ports use `.explicit`.
+- `acyclic-static-helper-provider-graphs`: helper and nested-provider frame graphs are static and acyclic.
+- `admitted-scalar-product-sum-carriers`: admitted scalar, product, and sum schemas retain their exact logical identities.
+- `closed-authored-failure-set`: `Body.Error` is closed and excludes reserved operational errors.
+- `bounded-frames-state-and-validation-work`: frame admission, state bytes, and generated validation work are bounded.
+- `native-and-wasm32-freestanding`: native and `wasm32-freestanding` compile gates are required.
+
+Unsupported:
+
+- `recursive-helper-provider-graphs`: rejected by StaticMachine v1.
+- `program-output-or-cleanup-hooks`: rejected by StaticMachine v1.
+- `mutable-string-list-carriers`: rejected by StaticMachine v1.
+- `comptime-struct-fields`: rejected by StaticMachine v1.
+- `non-exhaustive-enums`: rejected by StaticMachine v1.
+- `unrepresentable-compact-condition-histories`: rejected by StaticMachine v1.
+- `dynamic-provider-discovery`: outside StaticMachine v1.
+- `runtime-module-loading`: outside StaticMachine v1.
+- `v0-continuation-migration`: no transparent migration is supported.
 
 ## Proof gates
 
@@ -100,10 +138,15 @@ zig build check-boundary-static-machine-parity
 zig build check-boundary-static-machine-wasm32
 zig build check-boundary-static-machine-release
 zig build check-boundary-static-machine-release-falsifiers
+zig build check-boundary-static-machine-release-archive -- /path/to/boundary-v0.7.0.tar.gz
+zig build check-boundary-static-machine-release-archive-falsifiers
 zig build check --summary all
 ```
 
-The release verifier checks the public declarations, exact code identity,
-documentation-supplement digests, required matrix claims, and negative
-falsifiers. The existing StaticMachine, parity, wasm32, and aggregate gates
-remain the semantic proof.
+The focused release verifier checks public declarations, recorded code
+identity, documentation-supplement digests, owner-bound matrix claims, the
+StaticMachine rejection corpus, and negative falsifiers. The materialized
+archive verifier independently recomputes the archive SHA-256 and asks the
+pinned Zig toolchain to recompute the package hash from local bytes; it needs no
+network after the archive is present. The existing StaticMachine, parity,
+wasm32, and aggregate gates remain the semantic proof.

--- a/docs/static_machine_compatibility.md
+++ b/docs/static_machine_compatibility.md
@@ -32,9 +32,9 @@ release-closure commit.
 | Semantic parity authority | `Program.Session` on the admitted StaticMachine domain |
 
 World v1 closes `Machine.EffectRow`. It must not infer the residual static row
-from `Program.protocol`. World Application v1 accepts only machines whose
-`Machine.EffectRow.after_site_count == 0`; Boundary StaticMachine ABI v1 itself
-still admits statically known after sites.
+from `Program.protocol`.
+
+World Application v1 accepts only machines whose `Machine.EffectRow.after_site_count == 0`; Boundary StaticMachine ABI v1 itself still admits statically known after sites.
 
 ## Supported domain
 
@@ -69,8 +69,10 @@ Construction rejects these shapes at comptime:
   exactly;
 - after-continuation chains that do not close over their static input, output,
   and function-result types;
-- programs exceeding the fixed control-path, scratch-memory, or validation-work
-  ceilings.
+- programs exceeding the fixed control-path or validation-work ceilings.
+
+Scratch use is derived from the admitted control path and frame depth. Every
+admitted machine stays within the published scratch bound.
 
 There is no fallback to a loaded module, dynamic provider discovery, or runtime
 module loading. Broader programs remain usable through `Program.Session`; they
@@ -88,13 +90,10 @@ representation.
 - Nominal type renames preserve compatibility only when admitted carrier
   semantics are unchanged.
 - Logical field, enum discriminant, effect-site, or identity-bearing limit
-  changes alter the machine contract. `maximum_state_bytes` is identity-bearing
-  because it bounds canonical state images.
-- `debug_metadata` is diagnostic-only: changing it does not alter the portable
-  contract fingerprint or canonical state bytes.
-- `maximum_frames` is an admission bound: it must cover the reachable
-  helper/provider depth, but increasing an already sufficient value does not
-  alter the portable contract fingerprint or canonical state bytes.
+  changes alter the machine contract.
+- `maximum_state_bytes` is identity-bearing: changing it alters the machine contract because it bounds canonical state images.
+- `debug_metadata` is diagnostic-only: changing it does not alter the portable contract fingerprint or canonical state bytes.
+- `maximum_frames` is an admission bound: it must cover the reachable helper/provider depth, but increasing an already sufficient value does not alter the portable contract fingerprint or canonical state bytes.
 - `Program.Session` retains native-width `usize`, dynamic completion behavior,
   and its legacy reachability interpretation. StaticMachine v1 does not silently
   inherit those behaviors.
@@ -130,6 +129,8 @@ Unsupported:
 - `runtime-module-loading`: outside StaticMachine v1.
 - `v0-continuation-migration`: no transparent migration is supported.
 
+The focused release gate selects only registered `static_machine_*` compile-fail fixtures; it is representative rather than exhaustive, while the aggregate `compile-fail` gate retains the complete repository rejection corpus.
+
 ## Proof gates
 
 ```sh
@@ -138,15 +139,16 @@ zig build check-boundary-static-machine-parity
 zig build check-boundary-static-machine-wasm32
 zig build check-boundary-static-machine-release
 zig build check-boundary-static-machine-release-falsifiers
-zig build check-boundary-static-machine-release-archive -- /path/to/boundary-v0.7.0.tar.gz
+zig build check-boundary-static-machine-release-archive -Dboundary-release-archive=/path/to/boundary-v0.7.0.tar.gz
 zig build check-boundary-static-machine-release-archive-falsifiers
 zig build check --summary all
 ```
 
 The focused release verifier checks public declarations, recorded code
 identity, documentation-supplement digests, owner-bound matrix claims, the
-StaticMachine rejection corpus, and negative falsifiers. The materialized
-archive verifier independently recomputes the archive SHA-256 and asks the
-pinned Zig toolchain to recompute the package hash from local bytes; it needs no
-network after the archive is present. The existing StaticMachine, parity,
-wasm32, and aggregate gates remain the semantic proof.
+registered StaticMachine rejection corpus, and negative falsifiers. The
+materialized archive verifier snapshots one typed local input, recomputes its
+SHA-256, checks Zig `0.16.0`, and asks that toolchain to recompute the package
+hash from the same snapshot; it needs no network after the archive is present.
+The existing StaticMachine, parity, wasm32, aggregate, and full `compile-fail`
+gates remain the semantic proof.

--- a/docs/static_machine_compatibility.md
+++ b/docs/static_machine_compatibility.md
@@ -141,6 +141,7 @@ zig build check-boundary-static-machine-release
 zig build check-boundary-static-machine-release-falsifiers
 zig build check-boundary-static-machine-release-archive -Dboundary-release-archive=/path/to/boundary-v0.7.0.tar.gz
 zig build check-boundary-static-machine-release-archive-falsifiers
+sh conformance/static-machine-v1/release_archive_check_offline.sh zig /path/to/boundary-v0.7.0.tar.gz
 zig build check --summary all
 ```
 
@@ -150,5 +151,9 @@ registered StaticMachine rejection corpus, and negative falsifiers. The
 materialized archive verifier snapshots one typed local input, recomputes its
 SHA-256, checks Zig `0.16.0`, and asks that toolchain to recompute the package
 hash from the same snapshot; it needs no network after the archive is present.
+The direct `release_archive_check_offline.sh` command is the dependency-free
+network-free proof for a freshly materialized source package. The corresponding
+`zig build` command remains the cache-materialized build-graph proof and may
+resolve declared build dependencies when its caches are empty.
 The existing StaticMachine, parity, wasm32, aggregate, and full `compile-fail`
 gates remain the semantic proof.


### PR DESCRIPTION
## Summary

- publish a checked Boundary `v0.7.0` code-archive receipt with exact tag target, archive SHA-256, and Zig package hash
- identify the later documentation supplement separately through ordered file digests
- present `boundary.staticMachine` and `boundary.StaticMachineOptions` as supported primary surfaces beside `boundary.program`
- publish the StaticMachine ABI v1 compatibility matrix without widening its admitted domain
- add focused positive and deliberate-falsifier gates to the aggregate build

## Proof

- remote `v0.7.0^{}`: `7f2472100454aa2cd5c62e07db0c1e23eaf46a77`
- archive SHA-256: `25e5bd5ed45aac023ef99beee93f675ea4efb3f6eb1e98d2a13040d7451f0e9a`
- Zig package hash: `boundary-0.7.0-flclaCnjkABOSWaiSkxMBDQZsBEeA-Niai-l1u0q3A7_`
- `zig build check-boundary-static-machine-release`
- `zig build check-boundary-static-machine-release-falsifiers`
- `zig build lint -- --max-warnings 0`
- `zig build check --summary all`: 378/378 steps succeeded; 884/884 tests passed

## Semantic scope

No Boundary execution semantics, public exports, v0 manifests, serialized formats, or StaticMachine support restrictions change in this PR. Certified Boundary Modules remain available as an advanced compatibility surface.
