### PR TITLE
Release Boundary v1.0.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.0.0-rc.1",
+    .version = "1.0.0",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",


### PR DESCRIPTION
## Summary

- Promote Boundary's package identity from `1.0.0-rc.1` to stable `1.0.0`.
- Preserve the reviewed Machine ABI v2, ABL_RNF2 state, compiler, reducer, and proof topology unchanged.

## Proof

- `zig build check --summary all`: 199/199 steps succeeded; 153/153 tests passed.
- Stable identity check: `build.zig.zon` declares exactly `1.0.0` and contains no RC identity.
- Diff isolation: the exact head differs from `v1.0.0-rc.1` only in `build.zig.zon`'s version field.
- Performance gate: pass; RNF state 87 bytes versus 300-byte baseline, WASM 30,106 bytes versus 58,667-byte baseline.

## Scope

- Base: `68ad6fe0fd12c9dafc290bdde484f84ce7d7c211`
- Head: `754772efc2a72b8f31fb102a3c2d1d72757237fc`
- Changed path: `build.zig.zon`

## Follow-up

- Publish tag/release `v1.0.0`, compute its Zig package hash, then update World 2.0.0 to consume that exact stable Boundary identity.
