### PR TITLE
Add value-driven Control IR failures

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1132,6 +1132,61 @@ pub fn build(b: *std.Build) void {
     };
     compile_fail_step.dependOn(&vector_borrowed_slice_compilation.step);
 
+    const failure_value_type_mismatch_source = public_surface_compile_fail_sources.add("failure_value_type_mismatch.zig",
+        \\const cir = @import("control_ir");
+        \\const program_v2 = @import("program_v2");
+        \\
+        \\const blocks = [_]cir.Block{
+        \\    .{
+        \\        .id = 0,
+        \\        .parameters = &.{0},
+        \\        .terminator = .{ .fail_value = 0 },
+        \\    },
+        \\};
+        \\
+        \\const Body = struct {
+        \\    pub const InitialArgs = u32;
+        \\    pub const Result = void;
+        \\    pub const Failure = enum { rejected };
+        \\    pub const effect_sites = .{};
+        \\    pub const schema_types = .{};
+        \\    pub const control_ir: cir.Program = .{
+        \\        .label = "failure-value-type-mismatch",
+        \\        .value_types = &.{.{ .scalar = .u32 }},
+        \\        .blocks = &blocks,
+        \\        .entry = 0,
+        \\        .result_type = .{ .scalar = .unit },
+        \\    };
+        \\};
+        \\
+        \\const Machine = program_v2.program(
+        \\    "failure-value-type-mismatch",
+        \\    Body,
+        \\).compile(.{
+        \\    .maximum_frames = 2,
+        \\    .maximum_state_bytes = 1024,
+        \\    .maximum_machine_fuel = 8,
+        \\});
+        \\
+        \\comptime {
+        \\    _ = Machine.abi_version;
+        \\}
+    );
+    const failure_value_type_mismatch_module = b.createModule(.{
+        .root_source_file = failure_value_type_mismatch_source,
+        .target = b.graph.host,
+        .optimize = .Debug,
+    });
+    failure_value_type_mismatch_module.addImport("control_ir", host_core.control_ir);
+    failure_value_type_mismatch_module.addImport("program_v2", host_core.program_v2);
+    const failure_value_type_mismatch_compilation = b.addTest(.{
+        .root_module = failure_value_type_mismatch_module,
+    });
+    failure_value_type_mismatch_compilation.expect_errors = .{
+        .contains = "Control IR fail_value must reference Body.Failure",
+    };
+    compile_fail_step.dependOn(&failure_value_type_mismatch_compilation.step);
+
     const vector_source_authority_source = public_surface_compile_fail_sources.add("vector_source_authority.zig",
         \\const std = @import("std");
         \\const portable_value = @import("portable_value");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.0.0",
+    .version = "1.1.0",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/docs/program.md
+++ b/docs/program.md
@@ -32,6 +32,12 @@ bytecode. Its blocks define typed values, explicit edges, effects, helper calls,
 returns, and failures. Compilation validates the definition before RNF
 synthesis.
 
+Failures have two source forms. `.fail = tag` retains the compile-time failure
+tag used by existing programs. `.fail_value = value_id` returns the exact
+runtime value at that id and is admitted only when its type is exactly
+`Body.Failure`. Both lower through the same Machine ABI v2 `Outcome.failed`
+transition.
+
 `compiler_limits` has type `boundary.ir.CompilerLimits`. It can lower the
 implementation ceilings for values, blocks, constructors, constructor
 environments, invariants, and generated reducer work. These admission ceilings

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -329,6 +329,9 @@ fn segmentStoreType(
             included[@intCast(value)] = true;
         },
         .fail => {},
+        .fail_value => |value| {
+            included[@intCast(value)] = true;
+        },
     }
 
     var fields: [canonical.value_count]rnf.EnvironmentField = undefined;
@@ -1519,6 +1522,13 @@ fn validateBody(
                     @compileError("Control IR failure tag is outside Body.Failure");
                 }
             },
+            .fail_value => |value| {
+                if (typeForValue(Body, program.value_types[value]) != Body.Failure) {
+                    @compileError(
+                        "Control IR fail_value must reference Body.Failure",
+                    );
+                }
+            },
             else => {},
         }
     }
@@ -1736,6 +1746,10 @@ fn semanticHashTerminator(
             canonical.valueId(value),
         ),
         .fail => |failure| semanticHashU16(hasher, failure),
+        .fail_value => |value| semanticHashU16(
+            hasher,
+            canonical.valueId(value),
+        ),
     }
 }
 
@@ -3863,6 +3877,9 @@ pub fn DefinitionFor(comptime label: []const u8, comptime Body: type) type {
                 ) },
                 .fail => |failure| .{
                     .failed = failureFromTag(Body, failure),
+                },
+                .fail_value => |value| .{
+                    .failed = @field(store, valueName(value)),
                 },
             };
             return .{ .cost = accepted_cost, .transition = transition };

--- a/src/control_ir.zig
+++ b/src/control_ir.zig
@@ -197,6 +197,7 @@ pub const Terminator = union(enum) {
     return_value: ?ValueId,
     return_to_caller: ValueId,
     fail: u16,
+    fail_value: ValueId,
 };
 
 /// Compiler classification for persisted block entries.
@@ -420,7 +421,7 @@ pub fn Reachability(comptime maximum_blocks: usize) type {
                             suspension.continuation,
                         );
                     },
-                    .return_value, .return_to_caller, .fail => {},
+                    .return_value, .return_to_caller, .fail, .fail_value => {},
                 }
             }
             return result;
@@ -543,7 +544,7 @@ fn isIntraFunctionSuccessor(block: Block, target: BlockId) bool {
         .branch => |branch| branch.then_edge.target == target or
             branch.else_edge.target == target,
         .@"suspend" => |suspension| suspension.continuation.target == target,
-        .return_value, .return_to_caller, .fail => false,
+        .return_value, .return_to_caller, .fail, .fail_value => false,
     };
 }
 
@@ -900,6 +901,7 @@ pub fn validate(
                 }
             },
             .fail => {},
+            .fail_value => |value| try validateValue(program, value),
         }
     }
 
@@ -1104,6 +1106,15 @@ pub fn validate(
                 value,
             ),
             .fail => {},
+            .fail_value => |value| try validateUse(
+                maximum_values,
+                maximum_blocks,
+                definitions,
+                dominators,
+                block,
+                block.instructions.len,
+                value,
+            ),
         }
     }
 }
@@ -1151,7 +1162,7 @@ pub fn Liveness(
                 .@"suspend" => |suspension| {
                     self.transferEdge(program, suspension.continuation, &result);
                 },
-                .return_value, .return_to_caller, .fail => {},
+                .return_value, .return_to_caller, .fail, .fail_value => {},
             }
             return result;
         }
@@ -1187,6 +1198,7 @@ pub fn Liveness(
                     if (maybe_value) |value| _ = set.insert(value);
                 },
                 .return_to_caller => |value| _ = set.insert(value),
+                .fail_value => |value| _ = set.insert(value),
                 .jump, .fail => {},
             }
         }

--- a/src/rnf.zig
+++ b/src/rnf.zig
@@ -3650,7 +3650,7 @@ pub fn NormalForm(
                             &saw_predecessor,
                         );
                     },
-                    .return_value, .return_to_caller, .fail => {},
+                    .return_value, .return_to_caller, .fail, .fail_value => {},
                 }
             }
             return if (saw_predecessor) next else null;
@@ -3976,7 +3976,7 @@ pub fn NormalForm(
                             );
                         }
                     },
-                    .return_value, .return_to_caller, .fail => {},
+                    .return_value, .return_to_caller, .fail, .fail_value => {},
                 }
             }
             return result;

--- a/test/program_operations.zig
+++ b/test/program_operations.zig
@@ -390,3 +390,123 @@ test "non-dense failure tags retain name-bound runtime and identity semantics" {
         &FailureMachineB.Manifest.machine_contract_digest,
     ));
 }
+
+const DynamicFailure = enum {
+    rejected,
+    cancelled,
+};
+const DynamicFailureArgs = struct {
+    first: DynamicFailure,
+    second: DynamicFailure,
+};
+const dynamic_failure_value_types = [_]cir.ValueType{
+    .{ .schema = 0 },
+    .{ .schema = 1 },
+    .{ .schema = 1 },
+};
+const dynamic_failure_instructions = [_]cir.Instruction{
+    .{
+        .kind = .pure,
+        .result = 1,
+        .operands = &.{0},
+        .operation = .{ .product_extract = 0 },
+    },
+    .{
+        .kind = .pure,
+        .result = 2,
+        .operands = &.{0},
+        .operation = .{ .product_extract = 1 },
+    },
+};
+
+fn DynamicFailureBody(comptime selected_value: cir.ValueId) type {
+    return struct {
+        const dynamic_failure_blocks = [_]cir.Block{
+            .{
+                .id = 0,
+                .parameters = &.{0},
+                .instructions = &dynamic_failure_instructions,
+                .terminator = .{ .fail_value = selected_value },
+            },
+        };
+
+        pub const InitialArgs = DynamicFailureArgs;
+        pub const Result = void;
+        pub const Failure = DynamicFailure;
+        pub const effect_sites = .{};
+        pub const schema_types = .{ DynamicFailureArgs, DynamicFailure };
+        pub const control_ir: cir.Program = .{
+            .label = "value-driven-failure",
+            .value_types = &dynamic_failure_value_types,
+            .blocks = &dynamic_failure_blocks,
+            .entry = 0,
+            .result_type = .{ .scalar = .unit },
+        };
+    };
+}
+
+const FirstFailureMachine = program_v2.program(
+    "value-driven-failure",
+    DynamicFailureBody(1),
+).compile(.{
+    .maximum_frames = 2,
+    .maximum_state_bytes = 1024,
+    .maximum_machine_fuel = 16,
+});
+const SecondFailureMachine = program_v2.program(
+    "value-driven-failure",
+    DynamicFailureBody(2),
+).compile(.{
+    .maximum_frames = 2,
+    .maximum_state_bytes = 1024,
+    .maximum_machine_fuel = 16,
+});
+
+test "value-driven failure preserves runtime value and semantic identity" {
+    const args: DynamicFailureArgs = .{
+        .first = .rejected,
+        .second = .cancelled,
+    };
+
+    const first_state = try FirstFailureMachine.initialState(
+        std.testing.allocator,
+        args,
+    );
+    defer FirstFailureMachine.deinitState(first_state);
+    var first_fuel: u64 = 16;
+    switch (try FirstFailureMachine.step(first_state, &first_fuel)) {
+        .failed => |failure| switch (failure) {
+            .authored => |authored| try std.testing.expectEqual(
+                DynamicFailure.rejected,
+                authored,
+            ),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    const second_state = try SecondFailureMachine.initialState(
+        std.testing.allocator,
+        args,
+    );
+    defer SecondFailureMachine.deinitState(second_state);
+    var second_fuel: u64 = 16;
+    switch (try SecondFailureMachine.step(second_state, &second_fuel)) {
+        .failed => |failure| switch (failure) {
+            .authored => |authored| try std.testing.expectEqual(
+                DynamicFailure.cancelled,
+                authored,
+            ),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    try std.testing.expect(!std.mem.eql(
+        u8,
+        &FirstFailureMachine.Manifest.machine_contract_digest,
+        &SecondFailureMachine.Manifest.machine_contract_digest,
+    ));
+    try std.testing.expectEqual(@as(u32, 2), FirstFailureMachine.abi_version);
+    try std.testing.expectEqual(@as(u32, 2), SecondFailureMachine.abi_version);
+}


### PR DESCRIPTION
Adds a typed value-driven failure terminator to Boundary Control IR and promotes the package metadata to v1.1.0.

- preserves the existing static fail tag form
- validates fail_value against Body.Failure
- binds the selected ValueId into liveness and Machine identity
- lowers directly through Machine ABI v2 Outcome.failed

<!-- ship-proof:start -->
Validation:
- zig build check --summary all: 200/200 steps, 154/154 tests
- zig build lint -- --max-warnings 0: clean
- native/WASM parity: pass
- performance and deletion/no-interpreter gates: pass

Head: aa0ec675365e10b7c5432b9b6583433b5500e3c0
<!-- ship-proof:end -->