### PR TITLE
Raise bounded Control IR compiler capacity

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.1.0",
+    .version = "1.2.0",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -5,7 +5,7 @@ const rnf = @import("rnf");
 const std = @import("std");
 
 const implementation_limits: control_ir.CompilerLimits = .{};
-const compiler_evaluation_branch_quota = 1_000_000;
+const compiler_evaluation_branch_quota = 10_000_000;
 const dynamic_fuel_quantum_bytes: u64 = 16;
 // Advance this domain whenever deterministic segment charging changes.
 const segment_fuel_semantic_domain =

--- a/src/control_ir.zig
+++ b/src/control_ir.zig
@@ -268,7 +268,7 @@ pub const Program = struct {
 /// admission policy, not executable Machine semantics, and therefore do not
 /// enter the Machine contract digest when the generated RNF is unchanged.
 pub const CompilerLimits = struct {
-    maximum_values: usize = 64,
+    maximum_values: usize = 256,
     maximum_blocks: usize = 64,
     maximum_constructors: usize = 128,
     maximum_environment_fields: usize = 64,

--- a/test/program_compile.zig
+++ b/test/program_compile.zig
@@ -321,6 +321,56 @@ fn limitedIdentityBody(comptime constant_value: u32) type {
     };
 }
 
+fn largeValueBody(comptime value_count: usize) type {
+    comptime if (value_count < 65) {
+        @compileError("large Control IR fixture must cross the former 64-value ceiling");
+    };
+    return struct {
+        const value_types = [_]cir.ValueType{u32_type} ** value_count;
+        const instructions = blk: {
+            var result: [value_count - 1]cir.Instruction = undefined;
+            for (1..value_count) |index| {
+                result[index - 1] = .{
+                    .kind = .copy,
+                    .result = @intCast(index),
+                    .operands = &.{@as(cir.ValueId, @intCast(index - 1))},
+                    .operation = .copy,
+                };
+            }
+            break :blk result;
+        };
+        const large_blocks = [_]cir.Block{.{
+            .id = 0,
+            .parameters = &.{0},
+            .instructions = &instructions,
+            .terminator = .{ .return_value = value_count - 1 },
+        }};
+
+        pub const InitialArgs = u32;
+        pub const Result = u32;
+        pub const Failure = enum { rejected };
+        pub const effect_sites = .{};
+        pub const schema_types = .{};
+        pub const control_ir: cir.Program = .{
+            .label = "large-value-control-ir",
+            .value_types = &value_types,
+            .blocks = &large_blocks,
+            .entry = 0,
+            .result_type = u32_type,
+        };
+    };
+}
+
+const LargeValueProgram = program_v2.program(
+    "large-value-control-ir",
+    largeValueBody(96),
+);
+const LargeValueMachine = LargeValueProgram.compile(.{
+    .maximum_frames = 2,
+    .maximum_state_bytes = 1024,
+    .maximum_machine_fuel = 256,
+});
+
 test "Program.compile generates direct exact-live RNF Machine" {
     try std.testing.expectEqual(@as(usize, 3), Program.rnf.constructor_count);
     try std.testing.expect(
@@ -412,6 +462,21 @@ test "Program.compile generates direct exact-live RNF Machine" {
     };
     defer done.deinit();
     try std.testing.expectEqual(@as(u32, 42), done.value().*);
+}
+
+test "Program.compile admits a bounded Control IR above 64 values" {
+    try std.testing.expectEqual(@as(usize, 256), LargeValueProgram.compiler_limits.maximum_values);
+    try std.testing.expectEqual(@as(usize, 96), LargeValueProgram.control_ir.value_types.len);
+
+    const state = try LargeValueMachine.initialState(std.testing.allocator, @as(u32, 37));
+    defer LargeValueMachine.deinitState(state);
+    var fuel: u64 = 192;
+    const done = switch (try LargeValueMachine.step(state, &fuel)) {
+        .done => |result| result,
+        else => return error.TestUnexpectedResult,
+    };
+    defer done.deinit();
+    try std.testing.expectEqual(@as(u32, 37), done.value().*);
 }
 
 test "Machine canonicalizes typed initial and response ingress" {


### PR DESCRIPTION
## Outcome

- raises the compiler-only Control IR value ceiling from 64 to 256
- raises the bounded comptime evaluation quota for larger staged programs
- keeps Machine ABI v2 and semantic identities unchanged
- bumps the package release candidate to v1.2.0

## Proof

- `zig build check-boundary-machine --summary all` — 68/68 tests
- `zig build check --summary all` — 200/200 steps, 155/155 tests
- `zig build lint -- --max-warnings 0` — zero warnings
- downstream Agent `zig build check-agent-compiler --summary all` — 2/2 tests

The downstream fixture compiles and executes a generated ReAct machine with typed decision/tool continuations, counters/history, final return, and exact authored failure.
