### PR TITLE
Separate compiler defaults from staged-program capacity

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.2.0",
+    .version = "1.3.0",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -4,8 +4,15 @@ const portable_value = @import("portable_value");
 const rnf = @import("rnf");
 const std = @import("std");
 
-const implementation_limits: control_ir.CompilerLimits = .{};
-const compiler_evaluation_branch_quota = 10_000_000;
+const implementation_limits: control_ir.CompilerLimits = .{
+    .maximum_values = 256,
+    .maximum_blocks = 128,
+    .maximum_constructors = 256,
+    .maximum_environment_fields = 128,
+    .maximum_invariant_terms = 64,
+    .maximum_generated_operations = 32_768,
+};
+const compiler_evaluation_branch_quota = 50_000_000;
 const dynamic_fuel_quantum_bytes: u64 = 16;
 // Advance this domain whenever deterministic segment charging changes.
 const segment_fuel_semantic_domain =

--- a/src/control_ir.zig
+++ b/src/control_ir.zig
@@ -268,7 +268,7 @@ pub const Program = struct {
 /// admission policy, not executable Machine semantics, and therefore do not
 /// enter the Machine contract digest when the generated RNF is unchanged.
 pub const CompilerLimits = struct {
-    maximum_values: usize = 256,
+    maximum_values: usize = 64,
     maximum_blocks: usize = 64,
     maximum_constructors: usize = 128,
     maximum_environment_fields: usize = 64,

--- a/test/program_compile.zig
+++ b/test/program_compile.zig
@@ -351,6 +351,14 @@ fn largeValueBody(comptime value_count: usize) type {
         pub const Failure = enum { rejected };
         pub const effect_sites = .{};
         pub const schema_types = .{};
+        pub const compiler_limits: cir.CompilerLimits = .{
+            .maximum_values = value_count,
+            .maximum_blocks = 1,
+            .maximum_constructors = 4,
+            .maximum_environment_fields = 1,
+            .maximum_invariant_terms = 1,
+            .maximum_generated_operations = 256,
+        };
         pub const control_ir: cir.Program = .{
             .label = "large-value-control-ir",
             .value_types = &value_types,
@@ -465,7 +473,7 @@ test "Program.compile generates direct exact-live RNF Machine" {
 }
 
 test "Program.compile admits a bounded Control IR above 64 values" {
-    try std.testing.expectEqual(@as(usize, 256), LargeValueProgram.compiler_limits.maximum_values);
+    try std.testing.expectEqual(@as(usize, 96), LargeValueProgram.compiler_limits.maximum_values);
     try std.testing.expectEqual(@as(usize, 96), LargeValueProgram.control_ir.value_types.len);
 
     const state = try LargeValueMachine.initialState(std.testing.allocator, @as(u32, 37));


### PR DESCRIPTION
## Outcome

- restores Boundary's conservative 64-value default compiler policy
- separates private implementation maxima from caller-selected compiler limits
- admits larger staged programs only when they declare an explicit bounded profile
- raises the bounded compiler quota for the proved four-Machine Agent specialization matrix
- keeps Machine ABI v2, ABL_RNF2, and semantic identities unchanged
- bumps the package release candidate to v1.3.0

## Proof

- `zig build check --summary all` — 200/200 steps, 155/155 tests
- `zig build lint -- --max-warnings 0` — zero warnings
- downstream Agent `zig build check-agent-specialization-matrix --summary all` — four distinct Machines
- downstream Reflective ReAct lifecycle — 1/1 test

The 96-value Boundary fixture now opts into its own exact limit, while existing programs retain the original default compile budget.
