### PR TITLE
Fix union vector truncation at comptime

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.3.0",
+    .version = "1.3.1",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/src/portable_value.zig
+++ b/src/portable_value.zig
@@ -438,7 +438,7 @@ fn hasDeclSafe(comptime T: type, comptime name: []const u8) bool {
 }
 
 fn isBytes(comptime T: type) bool {
-    if (!hasDeclSafe(T, "portable_value_kind") or
+    if (comptime !hasDeclSafe(T, "portable_value_kind") or
         !hasDeclSafe(T, "portable_value_authenticity") or
         !hasDeclSafe(T, "maximum_length")) return false;
     if (@TypeOf(T.portable_value_kind) != PortableKind or
@@ -450,7 +450,7 @@ fn isBytes(comptime T: type) bool {
 }
 
 fn isText(comptime T: type) bool {
-    if (!hasDeclSafe(T, "portable_value_kind") or
+    if (comptime !hasDeclSafe(T, "portable_value_kind") or
         !hasDeclSafe(T, "portable_value_authenticity") or
         !hasDeclSafe(T, "maximum_length")) return false;
     if (@TypeOf(T.portable_value_kind) != PortableKind or
@@ -462,7 +462,7 @@ fn isText(comptime T: type) bool {
 }
 
 fn isVector(comptime T: type) bool {
-    if (!hasDeclSafe(T, "portable_value_kind") or
+    if (comptime !hasDeclSafe(T, "portable_value_kind") or
         !hasDeclSafe(T, "portable_value_authenticity") or
         !hasDeclSafe(T, "ElementType") or
         !hasDeclSafe(T, "maximum_length")) return false;
@@ -1405,6 +1405,26 @@ test "Vector canonicalizes nested elements at every ingress" {
     try std.testing.expectEqual(
         @as(u8, 0),
         pushed.storage[0].tags.storage[0].storage[1],
+    );
+}
+
+test "Vector truncate canonicalizes removed tagged-union integer payloads" {
+    const Element = union(enum) {
+        count: u32,
+        flag: bool,
+    };
+    const Items = Vector(Element, 2);
+
+    var items = try Items.fromSlice(&.{
+        Element{ .count = 42 },
+        Element{ .flag = true },
+    });
+    items.truncate(1);
+
+    try std.testing.expectEqual(@as(u32, 1), try items.len());
+    try std.testing.expectEqualDeep(
+        canonicalDefaultValue(Element),
+        items.storage[1],
     );
 }
 


### PR DESCRIPTION
## Outcome

Boundary vectors can now truncate tagged-union elements whose payloads include scalar types during comptime Machine planning.

## Change

- make portable type declaration guards explicitly comptime-lazy before member access
- add a regression for truncating a vector of tagged-union integer and boolean payloads
- set the package version to 1.3.1

## Proof

- focused regression: pass
- `zig build check --summary all`: 200/200 steps, 156/156 tests
- lint: zero warnings
- performance falsifiers: pass
- Machine ABI remains v2; state format remains ABL_RNF2
