### PR TITLE
Bound generated reducer optimization

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.3.1",
+    .version = "1.3.2",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -2967,7 +2967,10 @@ pub fn DefinitionFor(comptime label: []const u8, comptime Body: type) type {
             };
         }
 
-        fn executeInstructions(
+        // Keep each typed Control IR block as one direct code-generation unit.
+        // Inlining every block into the constructor dispatcher makes LLVM
+        // reconstruct one pathological monolithic reducer.
+        noinline fn executeInstructions(
             comptime block: control_ir.Block,
             store: anytype,
         ) ?Failure {
@@ -3754,7 +3757,8 @@ pub fn DefinitionFor(comptime label: []const u8, comptime Body: type) type {
             return fuel_cost;
         }
 
-        fn planConstructor(
+        // RNF constructors are the stable direct-reducer specialization seam.
+        noinline fn planConstructor(
             comptime constructor_id: usize,
             environment: anytype,
             accepted_cost: u64,

--- a/src/portable_value.zig
+++ b/src/portable_value.zig
@@ -505,6 +505,7 @@ fn hasCanonicalDefaultValue(comptime T: type) bool {
 
 /// Reject values without explicit first-order portable semantics.
 pub fn assertPortable(comptime T: type) void {
+    @setEvalBranchQuota(1_000_000);
     if (isBytes(T) or isText(T)) return;
     if (isVector(T)) {
         assertPortable(T.ElementType);
@@ -547,6 +548,38 @@ pub fn assertPortable(comptime T: type) void {
         },
         else => @compileError("unsupported Boundary Machine portable value: " ++ @typeName(T)),
     }
+}
+
+test "portable admission owns the comptime quota for deep closed values" {
+    const Payload = struct {
+        path: Text(256),
+        digest: Text(64),
+        contents: Text(32 * 1024),
+        rationale: Text(4096),
+        stdout: Text(32 * 1024),
+        stderr: Text(32 * 1024),
+        count: u32,
+        passed: bool,
+    };
+    const Observation = union(enum) {
+        one: Payload,
+        two: Payload,
+        three: Payload,
+        four: Payload,
+        five: Payload,
+        six: Payload,
+        seven: Payload,
+        eight: Payload,
+    };
+    const State = struct {
+        history: Vector(Observation, 12),
+        candidate: Observation,
+        prior: ?Observation,
+    };
+
+    comptime assertPortable(State);
+    const maximum = comptime maximumEncodedSize(State);
+    try std.testing.expect(maximum > 0);
 }
 
 fn canonicalDefaultValue(comptime T: type) T {


### PR DESCRIPTION
## What changed

- establish Boundary-owned comptime quota for deep admitted portable values
- preserve generated Control IR blocks and RNF constructors as non-inlined optimizer units
- add a deep portable-value regression fixture
- bump the package to 1.3.2

## Why

Agent Actuality produces a valid closed Action/history type that exceeds Zig's default comptime admission quota. Once admitted, LLVM previously inlined the complete generated reducer into one pathological monolith and remained in ModuleInliner/SimplifyCFG for more than 35 minutes. Keeping the existing semantic units as code-generation boundaries compiles the same import-free World application in about 55 seconds without adding an interpreter or changing Machine ABI v2.

## Validation

- `zig build check --summary all` — 200/200 steps, 157/157 tests
- exact downstream Agent Actuality World build — 55s WASM compile, zero imports, bounded 640-page memory, native/WASM manifest identity
- Boundary native/WASM parity, performance, malformed, deletion, single-reducer, compile-fail, lint, and release receipt gates all pass

## Tradeoff

The unusually large Actuality witness is 8.0 MiB before any post-link optimizer, above its reviewable 2 MiB target. This PR favors bounded compiler completion while preserving direct-reducer semantics; the downstream release review will disposition that measured size explicitly.