### PR TITLE
Publish Boundary Process v1 conformance corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ authority crosses the Machine boundary.
 - [Boundary Program Image v1](docs/boundary_executable_image_v1.md)
 - [Machine v2 Kernel v1](docs/boundary_kernel_v1.md)
 - [Process ABI v1](docs/process_v1.md)
+- [Process ABI v1 conformance corpus](docs/process_conformance_corpus_v1.md)
 - [Specialization equivalence](docs/specialization_equivalence.md)
 - [Migration to Boundary 1.7](docs/migration_to_1_7.md)
 - [Migration to Boundary 1.6](docs/migration_to_1_6.md)
@@ -113,8 +114,20 @@ Focused gates include `check-boundary-machine`, `check-boundary-rnf`,
 `check-boundary-machine-native-wasm`,
 `check-boundary-machine-no-interpreter`, and
 `check-boundary-machine-deletion`. Process conformance is available through
-`check-boundary-process-v1` and `emit-boundary-process-kernel-v1`. The aggregate also runs the real v0.7
-performance comparison and emits the Boundary-owned completion fields through
+`check-boundary-process-v1` and `emit-boundary-process-kernel-v1`. The immutable
+Boundary v1.7.0 Process corpus has its own check and emit steps:
+
+```text
+zig build check-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm --summary all
+zig build emit-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm --summary all
+```
+
+The explicit kernel path makes both operations network-free while retaining
+all kernel identity checks. Without it, the builder acquires and verifies the
+exact `v1.7.0` release asset. Release staging additionally supplies
+`-Dworld-process-host=/absolute/path/world-process-host-v1` so the local receipt
+binds the pinned World validator. The aggregate also runs the real v0.7 performance
+comparison and emits the Boundary-owned completion fields through
 `check-boundary-machine-receipt`.
 
 The aggregate is a release-owner gate and its historical performance lane

--- a/build.zig
+++ b/build.zig
@@ -859,6 +859,37 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const test_args = parseTestArgs(b);
+    const process_corpus_release_epoch = std.mem.find(
+        u8,
+        @embedFile("build.zig.zon"),
+        ".version = \"1.7.0\"",
+    ) != null;
+    const process_kernel_wasm_path = b.option(
+        []const u8,
+        "process-kernel-wasm",
+        "Absolute path to the exact Boundary v1.7.0 Process kernel; disables network acquisition.",
+    );
+    if (process_kernel_wasm_path) |path| {
+        if (!std.Io.Dir.path.isAbsolute(path)) {
+            std.process.fatal(
+                "-Dprocess-kernel-wasm must be an absolute path: {s}",
+                .{path},
+            );
+        }
+    }
+    const world_process_host_path = b.option(
+        []const u8,
+        "world-process-host",
+        "Absolute path to a pinned World Process-host worktree for release-staging validation.",
+    );
+    if (world_process_host_path) |path| {
+        if (!std.Io.Dir.path.isAbsolute(path)) {
+            std.process.fatal(
+                "-Dworld-process-host must be an absolute path: {s}",
+                .{path},
+            );
+        }
+    }
     const core = addCoreModules(b, target, optimize);
     const host_core = addCoreModules(b, b.graph.host, optimize);
 
@@ -1822,6 +1853,169 @@ pub fn build(b: *std.Build) void {
         process_kernel_wasm_reproducible.getEmittedBin(),
     );
     process_step.dependOn(&compare_process_kernel_wasm.step);
+    const process_corpus_scope_guard = b.addSystemCommand(&.{
+        "sh",
+        "-c",
+        \\set -eu
+        \\expected=4fd4cd959ea283a6b5af12a228f0d80a102683e3
+        \\tag_commit=$(git rev-parse --verify 'v1.7.0^{commit}')
+        \\test "$tag_commit" = "$expected"
+        \\git diff --quiet "$tag_commit" -- build.zig.zon
+        \\changed=$(
+        \\  {
+        \\    git diff --name-only "$tag_commit" -- src examples
+        \\    git ls-files --others --exclude-standard -- src examples
+        \\  } | sort -u
+        \\)
+        \\if test -n "$changed"; then
+        \\  printf '%s\n' "$changed" >&2
+        \\  exit 1
+        \\fi
+    });
+    process_corpus_scope_guard.setCwd(b.path("."));
+    process_corpus_scope_guard.has_side_effects = true;
+    const process_corpus_generator_commit = b.addSystemCommand(&.{
+        "sh",
+        "-c",
+        "set -eu; git rev-parse --verify 'HEAD^{commit}' | tr -d '\\n'",
+    });
+    process_corpus_generator_commit.setCwd(b.path("."));
+    process_corpus_generator_commit.has_side_effects = true;
+    const process_corpus_generator_commit_file =
+        process_corpus_generator_commit.captureStdOut(.{
+            .basename = "boundary-process-v1-conformance-generator-commit.txt",
+        });
+    const process_corpus_builder = b.addSystemCommand(&.{"node"});
+    process_corpus_builder.addFileArg(b.path(
+        "scripts/build_process_conformance_corpus.mjs",
+    ));
+    process_corpus_builder.addFileInput(b.path(
+        "scripts/check_process_conformance_corpus.mjs",
+    ));
+    process_corpus_builder.has_side_effects = true;
+    if (process_kernel_wasm_path) |path| {
+        process_corpus_builder.addArg("--kernel");
+        process_corpus_builder.addFileArg(.{ .cwd_relative = path });
+    }
+    process_corpus_builder.addArg("--local-kernel");
+    process_corpus_builder.addFileArg(
+        process_kernel_wasm_executable.getEmittedBin(),
+    );
+    process_corpus_builder.addArg("--vector-emitter");
+    process_corpus_builder.addArtifactArg(process_kernel_vector_executable);
+    process_corpus_builder.addArg("--capacity-emitter");
+    process_corpus_builder.addArtifactArg(capacity_vector_executable);
+    process_corpus_builder.addArg("--generator-commit");
+    process_corpus_builder.addFileContentArg(
+        process_corpus_generator_commit_file,
+    );
+    if (world_process_host_path) |path| {
+        const world_root: std.Build.LazyPath = .{ .cwd_relative = path };
+        const world_validator = world_root.path(
+            b,
+            "scripts/acquire_process_conformance_assets.mjs",
+        );
+        const world_commit_command = b.addSystemCommand(&.{
+            "sh",
+            "-c",
+            "set -eu; git rev-parse --verify 'HEAD^{commit}' | tr -d '\\n'",
+        });
+        world_commit_command.setCwd(world_root);
+        world_commit_command.has_side_effects = true;
+        const world_commit = world_commit_command.captureStdOut(.{
+            .basename = "world-process-host-commit.txt",
+        });
+        const world_validator_sha_command = b.addSystemCommand(&.{
+            "sh",
+            "-c",
+            "set -eu; shasum -a 256 \"$1\" | awk '{printf \"%s\", $1}'",
+            "sh",
+        });
+        world_validator_sha_command.addFileArg(world_validator);
+        const world_validator_sha =
+            world_validator_sha_command.captureStdOut(.{
+                .basename = "world-process-validator-sha256.txt",
+            });
+        process_corpus_builder.addArg("--world-validator");
+        process_corpus_builder.addFileArg(world_validator);
+        process_corpus_builder.addArg("--world-commit");
+        process_corpus_builder.addFileContentArg(world_commit);
+        process_corpus_builder.addArg("--world-validator-sha256");
+        process_corpus_builder.addFileContentArg(world_validator_sha);
+    }
+    process_corpus_builder.addArg("--output-dir");
+    const process_corpus_output = process_corpus_builder.addOutputDirectoryArg(
+        "boundary-process-v1-conformance",
+    );
+    const process_corpus_manifest = process_corpus_output.path(
+        b,
+        "boundary-process-v1-conformance-corpus.json",
+    );
+    const process_corpus_payload = process_corpus_output.path(
+        b,
+        "boundary-process-v1-conformance-corpus.bin",
+    );
+    const process_corpus_receipt = process_corpus_output.path(
+        b,
+        "boundary-process-v1-conformance-generation-receipt.json",
+    );
+    const process_corpus_validator = b.addSystemCommand(&.{"node"});
+    process_corpus_validator.addFileArg(b.path(
+        "scripts/check_process_conformance_corpus.mjs",
+    ));
+    process_corpus_validator.addFileArg(process_corpus_manifest);
+    process_corpus_validator.addFileArg(process_corpus_payload);
+    const process_corpus_negative = b.addSystemCommand(&.{"node"});
+    process_corpus_negative.addFileArg(b.path(
+        "test/process_conformance_corpus_v1.mjs",
+    ));
+    process_corpus_negative.addFileInput(b.path(
+        "scripts/build_process_conformance_corpus.mjs",
+    ));
+    process_corpus_negative.addFileInput(b.path(
+        "scripts/check_process_conformance_corpus.mjs",
+    ));
+    process_corpus_negative.addFileArg(process_corpus_manifest);
+    process_corpus_negative.addFileArg(process_corpus_payload);
+    process_corpus_negative.addFileArg(
+        process_kernel_wasm_executable.getEmittedBin(),
+    );
+    const process_corpus_check_step = b.step(
+        "check-boundary-process-v1-conformance-corpus",
+        "Build and verify the immutable Boundary v1.7.0 Process corpus.",
+    );
+    process_corpus_check_step.dependOn(&process_corpus_builder.step);
+    process_corpus_check_step.dependOn(&process_corpus_validator.step);
+    process_corpus_check_step.dependOn(&process_corpus_negative.step);
+    process_corpus_check_step.dependOn(&process_corpus_scope_guard.step);
+    process_corpus_check_step.dependOn(&compare_process_kernel_wasm.step);
+    const install_process_corpus_manifest = b.addInstallFile(
+        process_corpus_manifest,
+        "boundary-process-v1-conformance/boundary-process-v1-conformance-corpus.json",
+    );
+    const install_process_corpus_payload = b.addInstallFile(
+        process_corpus_payload,
+        "boundary-process-v1-conformance/boundary-process-v1-conformance-corpus.bin",
+    );
+    const install_process_corpus_receipt = b.addInstallFile(
+        process_corpus_receipt,
+        "boundary-process-v1-conformance/boundary-process-v1-conformance-generation-receipt.json",
+    );
+    inline for (.{
+        install_process_corpus_manifest,
+        install_process_corpus_payload,
+        install_process_corpus_receipt,
+    }) |installation| installation.step.dependOn(process_corpus_check_step);
+    const emit_process_corpus_step = b.step(
+        "emit-boundary-process-v1-conformance-corpus",
+        "Install the exact Process corpus pair and local generation receipt.",
+    );
+    emit_process_corpus_step.dependOn(process_corpus_check_step);
+    inline for (.{
+        install_process_corpus_manifest,
+        install_process_corpus_payload,
+        install_process_corpus_receipt,
+    }) |installation| emit_process_corpus_step.dependOn(&installation.step);
     const kernel_wasm_reproducible = b.addExecutable(.{
         .name = "boundary-machine-v2-kernel-v1-reproducible",
         .root_module = wasm_repro_core.kernel_wasm_v1,
@@ -2918,10 +3112,16 @@ pub fn build(b: *std.Build) void {
     check_step.dependOn(release_proof_step);
     check_step.dependOn(receipt_step);
     check_step.dependOn(process_step);
+    if (process_corpus_release_epoch) {
+        check_step.dependOn(process_corpus_check_step);
+    }
 
     requireDirectDependency(&receipt_command.step, release_proof_step);
     requireDirectDependency(receipt_step, &receipt_command.step);
     requireDirectDependency(check_step, release_proof_step);
     requireDirectDependency(check_step, receipt_step);
     requireDirectDependency(check_step, process_step);
+    if (process_corpus_release_epoch) {
+        requireDirectDependency(check_step, process_corpus_check_step);
+    }
 }

--- a/docs/process_conformance_corpus_v1.md
+++ b/docs/process_conformance_corpus_v1.md
@@ -1,0 +1,243 @@
+# Boundary Process ABI v1 conformance corpus
+
+Boundary's v1.7.0 evidence backfill defines an immutable Process ABI v1
+conformance oracle for external hosts. Once the asset pair is attached, a host
+given canonical BPI1 plus InitialArgs or `ABL_PST1` Process State, and an
+optional `ABL_ERS1` EffectResult, can invoke the fixed Boundary Process kernel
+and compare its canonical `ABL_PKO1` bytes with the Boundary-owned expected
+bytes.
+
+This corpus is release evidence. It is not required for ordinary Boundary use
+and does not add another runtime, host, test framework, linker, wire format, or
+semantic layer.
+
+## Producer and assets
+
+The semantic producer tuple is fixed:
+
+```text
+repository:                 tkersey/boundary
+release tag:                v1.7.0
+release URL:                https://github.com/tkersey/boundary/releases/tag/v1.7.0
+commit:                     4fd4cd959ea283a6b5af12a228f0d80a102683e3
+Boundary version:           1.7.0
+Process Kernel ABI:         1
+kernel byte length:         647473
+kernel SHA-256:             178f9c2fb79402a85ab5a7905586879347ad5c99f988127eec001c9ecfd813f0
+kernel imports:             0
+```
+
+The release backfill attaches exactly two corpus assets to Boundary v1.7.0:
+
+```text
+boundary-process-v1-conformance-corpus.json
+boundary-process-v1-conformance-corpus.bin
+```
+
+The JSON is the closed manifest and partition map. The BIN is a headerless
+concatenation of all referenced artifacts. There is no archive wrapper or
+checksum sidecar. The manifest binds the complete BIN and every artifact slice;
+GitHub release metadata binds both assets.
+
+## Ownership and parity law
+
+Boundary owns the expected outcomes because it owns both implementations whose
+agreement establishes them:
+
+```text
+process_advance_v1 native outcome
+    == exact released boundary-process-kernel-v1.wasm outcome
+    == published expected ABL_PKO1 artifact
+```
+
+The native emitter calls the Process reference implementation and canonical
+outcome encoders; it does not reimplement reduction. Corpus construction
+compiles the immutable WebAssembly module once, creates a fresh instance for
+each vector, invokes one Process operation, and rejects before asset construction
+on the first byte difference.
+
+World #47 is a consumer of this evidence. It validates the manifest and payload,
+runs the fixed Boundary kernel as a host, and compares the result with the
+Boundary-owned expected bytes:
+
+```text
+World-hosted fixed Boundary kernel outcome
+    == published expected ABL_PKO1 artifact
+```
+
+World does not invent, normalize, or replace expected Process outcomes.
+
+## Vectors and scenarios
+
+The manifest contains exactly these 20 vectors in this order:
+
+| Index | Vector ID | Input | EffectResult | Expected kind | Scenarios |
+| ---: | --- | --- | --- | --- | --- |
+| 0 | `typed-effect-initial` | `initialArgs` | none | `Requested` | `typed-residual-effect`, `non-agent` |
+| 1 | `pending-request-reconstruction` | `state` | none | `Requested` | `pending-request-reconstruction` |
+| 2 | `typed-resume` | `state` | present | `Completed` | `typed-resume`, `completion` |
+| 3 | `initial-progress` | `initialArgs` | none | `Progressed` | `initial-progress` |
+| 4 | `explicit-yield` | `initialArgs` | none | `ExplicitlyYielded` | `explicit-yield` |
+| 5 | `authored-failure-v1` | `initialArgs` | none | `AuthoredFailure` | `authored-failure-v1` |
+| 6 | `authored-failure-v2-bad-math-progress` | `initialArgs` | none | `Progressed` | `authored-failure-v2` |
+| 7 | `authored-failure-v2-bad-math` | `state` | none | `AuthoredFailure` | `authored-failure-v2` |
+| 8 | `authored-failure-v2-bad-position-progress` | `initialArgs` | none | `Progressed` | `authored-failure-v2` |
+| 9 | `authored-failure-v2-bad-position` | `state` | none | `AuthoredFailure` | `authored-failure-v2` |
+| 10 | `authored-failure-v2-success` | `initialArgs` | none | `Completed` | `authored-failure-v2`, `completion` |
+| 11 | `effect-morphism` | `initialArgs` | none | `Requested` | `effect-morphism`, `typed-residual-effect` |
+| 12 | `recursion-call` | `initialArgs` | none | `Progressed` | `recursive-call-return`, `initial-progress` |
+| 13 | `recursion-branch` | `state` | none | `Progressed` | `recursive-call-return`, `ordinary-progress` |
+| 14 | `recursion-recur` | `state` | none | `Progressed` | `recursive-call-return`, `ordinary-progress` |
+| 15 | `recursion-base-branch` | `state` | none | `Progressed` | `recursive-call-return`, `ordinary-progress` |
+| 16 | `recursion-return-inner` | `state` | none | `Progressed` | `recursive-call-return`, `ordinary-progress` |
+| 17 | `recursion-return-root` | `state` | none | `Progressed` | `recursive-call-return`, `ordinary-progress` |
+| 18 | `recursion-complete` | `state` | none | `Completed` | `recursive-call-return`, `completion` |
+| 19 | `needs-capacity` | `initialArgs` | none | `NeedsCapacity` | `needs-capacity` |
+
+Their nonempty scenario arrays cover exactly these 13 admitted scenario names:
+
+```text
+initial-progress
+ordinary-progress
+typed-residual-effect
+effect-morphism
+recursive-call-return
+explicit-yield
+completion
+authored-failure-v1
+authored-failure-v2
+pending-request-reconstruction
+typed-resume
+needs-capacity
+non-agent
+```
+
+The sequence proves an initial typed residual request, exact pending-request
+reconstruction, typed resume, one-step progress, explicit yield, evaluator
+semantics v1 and v2 authored failures, effect reification, recursive call and
+return through terminal completion, and default-kernel operational capacity.
+The typed effect fixture is deliberately a generic non-Agent program.
+
+## Payload partition
+
+Every vector contributes distinct image, instance, and expected-outcome
+artifacts. Only `typed-resume` also contributes an EffectResult artifact:
+
+```text
+20 image artifacts
+20 instance artifacts
+1 EffectResult artifact
+20 expected-outcome artifacts
+61 artifacts total
+```
+
+Vectors appear in the order above. Within each vector the BIN appends image,
+instance, optional EffectResult, then expected outcome. Artifacts are not
+deduplicated even when their bytes repeat. Each manifest record binds its ID,
+contiguous offset, byte length, and lowercase SHA-256. The 61 records cover the
+BIN from offset zero to its exact end with no gap, overlap, unreferenced slice,
+or unreferenced artifact.
+
+For every vector, `nativeOutcomeSha256`, `kernelOutcomeSha256`, and the digest
+of the referenced expected-outcome artifact are equal. The manifest also binds
+the complete payload digest and length.
+
+## Default-kernel `NeedsCapacity`
+
+The `needs-capacity` vector targets the released default kernel, not a
+constrained test kernel. Its valid small non-Agent BPI1 image and deterministic
+zero-filled InitialArgs artifact make the encoded `ABL_PKI1` input exactly one
+byte larger than the default 32 MiB input arena:
+
+```text
+required ABL_PKI1 bytes:       33554433
+minimum_input_bytes:           33554433
+minimum_output_bytes:          64
+minimum_scratch_bytes:         0
+minimum_memory_pages:          2457
+```
+
+The encoded input has a 40-byte header, so its instance length is
+`33554433 - 40 - image byte length`. The builder passes the exact image and
+instance lengths to `boundary_process_kernel_prepare_input`. Preparation
+returns zero and publishes the canonical 64-byte `NeedsCapacity` outcome before
+any image or instance payload byte is copied into guest memory. The native
+reference independently derives the same four requirement fields from the
+released kernel's live-page, occupied-memory, and input-capacity probe values.
+
+This vector proves transactional default-host preflight behavior. It does not
+claim that an oversized instance is semantically valid after capacity is added,
+and it does not repurpose the constrained-output-capacity fixture.
+
+## Build and validate
+
+With a preverified local copy of the exact released kernel, run network-free:
+
+```text
+zig build check-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm --summary all
+zig build emit-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm --summary all
+zig build emit-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm -Dworld-process-host=/absolute/path/world-process-host-v1 --summary all
+```
+
+The check rebuilds the local Process kernel, requires byte identity with the
+released kernel, emits the native vectors, proves 20/20 native/kernel parity,
+validates the closed manifest and complete partition, runs focused negative
+gates, and performs two independent byte-identical rebuilds.
+
+The emit step installs only:
+
+```text
+zig-out/boundary-process-v1-conformance/
+  boundary-process-v1-conformance-corpus.json
+  boundary-process-v1-conformance-corpus.bin
+  boundary-process-v1-conformance-generation-receipt.json
+```
+
+The generation receipt is local evidence and is not a release asset or a BIN
+artifact. When `-Dprocess-kernel-wasm` is omitted, the builder acquires the
+exact `v1.7.0` release asset and verifies its tag target, release metadata,
+filename, byte length, digest, import set, ABI version, and required exports.
+An override changes only acquisition: it must pass the same byte and module
+identity checks, and its local path never enters manifest bytes.
+
+The third command is the release-staging form. It passes the generated pair to
+the pinned World #47 manifest and payload validators and finalizes
+`worldContractValidated: true` only after they accept the exact bytes. This does
+not replace Boundary's stricter exact-inventory validation or the
+native/fixed-kernel execution proof.
+
+## Release backfill
+
+The corpus is added to the existing Boundary v1.7.0 release because it supplies
+evidence for unchanged v1.7.0 semantics. The tag remains at
+`4fd4cd959ea283a6b5af12a228f0d80a102683e3`; it is not moved or recreated, no
+v1.7.1 is minted, and no existing asset is replaced.
+
+Before upload, regenerate from the clean merged tooling commit, require two
+independent identical builds, validate with Boundary and World, peel the release
+tag again, and inspect both required asset names. If a name already exists,
+download it and compare its metadata, full bytes, and conformance:
+
+- retain it when it is byte-identical;
+- upload only a missing peer after any existing peer is proved identical;
+- stop on any difference, upload refusal, tag drift, or unstable digest evidence;
+- never delete and silently replace a public corpus asset.
+
+After upload, read the release API back, anonymously redownload both assets,
+revalidate the public pair, and require World #47 public acquisition to lock the
+same `v1.7.0` producer tuple and 20-vector manifest. Once World locks the assets,
+they are immutable. A discovered defect requires a new successor Process tuple,
+not replacement of this evidence.
+
+## Non-claims
+
+The corpus does not change BPI1, Process ABI v1, `ABL_PST1`, `ABL_ERQ1`,
+`ABL_ERS1`, `ABL_PKO1`, the Process kernel ABI or bytes, native Process
+semantics, Machine ABI v2, or any public Boundary API. It does not provide World
+host code, an Agent transcript, capability adapters, persistent Process storage,
+scheduling, linking, multi-shot resumptions, or application-specific WebAssembly.
+
+Boundary publication proves generic Process semantic truth only. The separate
+Agent transcript remains a high-complexity downstream witness, and World must
+prove that it hosts both. Publishing this corpus alone does not complete World
+conformance.

--- a/docs/process_v1.md
+++ b/docs/process_v1.md
@@ -104,9 +104,34 @@ new arena cannot be omitted from the calculation or its omission witness. Each
 growth delta uses the arena's aligned physical size rather than only its logical
 payload length.
 
+## Published conformance corpus
+
+The Boundary v1.7.0 evidence backfill is defined by the Process ABI v1
+host-conformance assets
+`boundary-process-v1-conformance-corpus.json` and
+`boundary-process-v1-conformance-corpus.bin`. Boundary owns their canonical
+inputs and expected `ABL_PKO1` bytes because it owns both the native Process
+reference semantics and the fixed `boundary-process-kernel-v1.wasm`. Each
+expected outcome is admitted only after the native result and the exact released
+kernel result are byte-identical.
+
+The corpus is an immutable conformance oracle for external hosts such as World.
+World consumes and checks the Boundary-owned bytes; it does not author expected
+Process outcomes. The corpus is not required for ordinary Boundary compilation
+or execution and is not a runtime, host, scheduler, linker, or semantic layer.
+See [Process ABI v1 conformance corpus](process_conformance_corpus_v1.md) for the
+producer tuple, vector inventory, payload partition, capacity witness, and
+release-backfill rules.
+
 Run:
 
 ```text
 zig build check-boundary-process-v1 --summary all
 zig build emit-boundary-process-kernel-v1
+zig build check-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm --summary all
+zig build emit-boundary-process-v1-conformance-corpus -Dprocess-kernel-wasm=/absolute/path/boundary-process-kernel-v1.wasm --summary all
 ```
+
+Release staging adds
+`-Dworld-process-host=/absolute/path/world-process-host-v1` so the local receipt
+binds successful validation by the pinned World #47 source.

--- a/scripts/build_process_conformance_corpus.mjs
+++ b/scripts/build_process_conformance_corpus.mjs
@@ -531,9 +531,25 @@ function verifyParityRecords(records) {
   for (const record of records) {
     assertOutcomeParity(record.id, record.nativeOutcome, record.kernelOutcome);
   }
+  const ownedRecords = records.map((record) => Object.freeze({
+    id: record.id,
+    operation: record.operation,
+    input: Object.freeze({
+      bytes: Buffer.from(record.input.bytes),
+      instanceKind: record.input.instanceKind,
+      effectResultPresent: record.input.effectResultPresent,
+      image: Buffer.from(record.input.image),
+      instance: Buffer.from(record.input.instance),
+      effectResult: record.input.effectResult === null
+        ? null
+        : Buffer.from(record.input.effectResult),
+    }),
+    nativeOutcome: Buffer.from(record.nativeOutcome),
+    kernelOutcome: Buffer.from(record.kernelOutcome),
+  }));
   return Object.freeze({
     [verifiedParityBrand]: true,
-    records: Object.freeze([...records]),
+    records: Object.freeze(ownedRecords),
   });
 }
 
@@ -898,10 +914,12 @@ export function validateWorldSourceIdentity(options) {
 async function validateWithWorld(options, manifestBytes, payloadBytes) {
   const supplied = [options.worldValidator, options.worldCommit, options.worldValidatorSha256];
   if (supplied.every((value) => value === undefined)) return false;
-  const { observedDigest } = validateWorldSourceIdentity(options);
+  const { source, observedDigest } = validateWorldSourceIdentity(options);
   let module;
   try {
-    module = await import(`${pathToFileURL(path.resolve(options.worldValidator)).href}?sha256=${observedDigest}`);
+    module = await import(
+      `data:text/javascript;base64,${source.toString("base64")}#sha256=${observedDigest}`,
+    );
   } catch (error) {
     fail("WORLD_CONTRACT_REJECTED", "could not load the pinned World validator", {
       cause: error?.message ?? String(error),

--- a/scripts/build_process_conformance_corpus.mjs
+++ b/scripts/build_process_conformance_corpus.mjs
@@ -1,0 +1,1229 @@
+#!/usr/bin/env node
+
+import childProcess from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  CORPUS_IDENTITY,
+  EXPECTED_ARTIFACT_IDS,
+  OUTCOME_KIND_BY_BYTE,
+  VECTOR_DESCRIPTORS,
+  canonicalJsonBytes,
+  sha256Hex,
+  validateCanonicalOutcome,
+  validateCorpusBytes,
+} from "./check_process_conformance_corpus.mjs";
+
+const STREAM_MAGIC = Buffer.from([0x42, 0x50, 0x43, 0x47, 0x45, 0x4e, 0x31, 0x00]);
+const STREAM_VERSION = 1;
+const MAX_NATIVE_STREAM_BYTES = 64 * 1024 * 1024;
+const MAX_KERNEL_BYTES = 64 * 1024 * 1024;
+const KERNEL_ASSET_NAME = "boundary-process-kernel-v1.wasm";
+const PROCESS_INPUT_HEADER_BYTES = 40;
+const DEFAULT_INPUT_CAPACITY = 32 * 1024 * 1024;
+const EXPECTED_LIVE_PAGES = 2_457;
+const EXPECTED_OCCUPIED_BYTES = 160_977_264n;
+const NEEDS_CAPACITY_INPUT_BYTES = 33_554_433;
+const NEEDS_CAPACITY_IMAGE_BYTES = 746;
+const NEEDS_CAPACITY_IMAGE_SHA256 = "b62f6ea3a307fc600be79894ebd242fa07d8972e90c34194dd4219ecfc427d00";
+const NEEDS_CAPACITY_INSTANCE_BYTES = 33_553_647;
+const NEEDS_CAPACITY_INSTANCE_SHA256 = "c039e4fb3ff6b2f59a9cc823a84e56c4db7cdf21033ce6496d04d6cbd1e9da28";
+const NEEDS_CAPACITY_OUTCOME_SHA256 = "d39288fd5bd8184a3edd7b69d4681d5908f05433664794090287af348a7b305a";
+const WORLD_VALIDATOR_COMMIT = "4258cd681b4b3e79d423c19999bb2c5b8615f03e";
+const WORLD_VALIDATOR_SHA256 = "42a11ef293a57b41bb0151c7089199756438a26a0d47744fe9cc50bc693dcf44";
+const WORLD_VALIDATOR_RELATIVE = "scripts/acquire_process_conformance_assets.mjs";
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+const GENERATOR_SOURCE_PATHS = Object.freeze([
+  "build.zig",
+  "test/process_kernel_vector.zig",
+  "test/process_kernel_capacity_vector.zig",
+  "scripts/build_process_conformance_corpus.mjs",
+  "scripts/check_process_conformance_corpus.mjs",
+]);
+const SUBPROCESS_TIMEOUT_MS = 120_000;
+
+export const REQUIRED_KERNEL_EXPORTS = Object.freeze([
+  Object.freeze({ name: "memory", kind: "memory" }),
+  Object.freeze({ name: "boundary_process_kernel_abi_version", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_reserve", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_input_ptr", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_input_capacity", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_input_payload_ptr", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_occupied_memory_bytes", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_prepare_input", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_execute", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_output_ptr", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_output_len", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_error_ptr", kind: "function" }),
+  Object.freeze({ name: "boundary_process_kernel_error_len", kind: "function" }),
+]);
+
+export class CorpusBuildError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "CorpusBuildError";
+    this.code = code;
+    this.details = Object.freeze({ ...details });
+  }
+}
+
+function fail(code, message, details = {}) {
+  throw new CorpusBuildError(code, message, details);
+}
+
+function exactSafeU64(buffer, offset, label) {
+  const value = buffer.readBigUInt64LE(offset);
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    fail("NATIVE_STREAM_INVALID", `${label} is not an exact safe integer`, { label, value: String(value) });
+  }
+  return Number(value);
+}
+
+function allZero(bytes) {
+  return !bytes.some((byte) => byte !== 0);
+}
+
+function canonicalIdentifier(value, label) {
+  if (!/^[a-z0-9][a-z0-9._-]{0,127}$/.test(value)) {
+    fail("NATIVE_STREAM_INVALID", `${label} is not a canonical identifier`, { label, value });
+  }
+  return value;
+}
+
+export function parseKernelInput(bytes, label = "kernel input") {
+  const input = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (input.length < PROCESS_INPUT_HEADER_BYTES ||
+      !input.subarray(0, 8).equals(Buffer.from("ABL_PKI1")) ||
+      input.readUInt16LE(8) !== 1 || input[10] > 1 || input[11] > 1 ||
+      !allZero(input.subarray(36, 40))) {
+    fail("NATIVE_STREAM_INVALID", `${label} has a malformed ABL_PKI1 header`, { label });
+  }
+  const imageLength = exactSafeU64(input, 12, `${label} image length`);
+  const instanceLength = exactSafeU64(input, 20, `${label} instance length`);
+  const effectResultLength = exactSafeU64(input, 28, `${label} EffectResult length`);
+  const effectResultPresent = input[11] === 1;
+  if (!effectResultPresent && effectResultLength !== 0) {
+    fail("NATIVE_STREAM_INVALID", `${label} has absent nonempty EffectResult bytes`, { label });
+  }
+  const total = PROCESS_INPUT_HEADER_BYTES + imageLength + instanceLength + effectResultLength;
+  if (!Number.isSafeInteger(total) || total !== input.length) {
+    fail("NATIVE_STREAM_INVALID", `${label} lengths do not cover the complete input`, {
+      label, expected: total, observed: input.length,
+    });
+  }
+  const imageStart = PROCESS_INPUT_HEADER_BYTES;
+  const instanceStart = imageStart + imageLength;
+  const effectResultStart = instanceStart + instanceLength;
+  return Object.freeze({
+    bytes: input,
+    instanceKind: input[10] === 0 ? "initialArgs" : "state",
+    effectResultPresent,
+    image: input.subarray(imageStart, instanceStart),
+    instance: input.subarray(instanceStart, effectResultStart),
+    effectResult: effectResultPresent ? input.subarray(effectResultStart) : null,
+  });
+}
+
+export function parseNativeStream(bytes, label = "native vector stream") {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < 16 ||
+      bytes.byteLength > MAX_NATIVE_STREAM_BYTES) {
+    fail("NATIVE_STREAM_INVALID", `${label} has an invalid byte length`, {
+      label, byteLength: bytes?.byteLength, maximum: MAX_NATIVE_STREAM_BYTES,
+    });
+  }
+  const stream = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (!stream.subarray(0, 8).equals(STREAM_MAGIC) || stream.readUInt32LE(8) !== STREAM_VERSION) {
+    fail("NATIVE_STREAM_INVALID", `${label} has the wrong BPCGEN1 stream identity`, { label });
+  }
+  const count = stream.readUInt32LE(12);
+  if (count === 0 || count > VECTOR_DESCRIPTORS.length) {
+    fail("NATIVE_STREAM_INVALID", `${label} has an invalid record count`, { label, count });
+  }
+  let cursor = 16;
+  const records = [];
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (let index = 0; index < count; index += 1) {
+    if (stream.length - cursor < 20) {
+      fail("NATIVE_STREAM_INVALID", `${label} ends inside record ${index}`, { label, index });
+    }
+    const idLength = stream.readUInt16LE(cursor);
+    const operationByte = stream[cursor + 2];
+    const reserved = stream[cursor + 3];
+    const inputLength = exactSafeU64(stream, cursor + 4, `${label} record ${index} PKI1 length`);
+    const outcomeLength = exactSafeU64(stream, cursor + 12, `${label} record ${index} PKO1 length`);
+    cursor += 20;
+    if (idLength === 0 || idLength > 128 || operationByte > 1 || reserved !== 0) {
+      fail("NATIVE_STREAM_INVALID", `${label} record ${index} has an invalid header`, { label, index });
+    }
+    const recordLength = idLength + inputLength + outcomeLength;
+    if (!Number.isSafeInteger(recordLength) || recordLength > stream.length - cursor) {
+      fail("NATIVE_STREAM_INVALID", `${label} record ${index} extends outside the stream`, { label, index });
+    }
+    let id;
+    try {
+      id = decoder.decode(stream.subarray(cursor, cursor + idLength));
+    } catch {
+      fail("NATIVE_STREAM_INVALID", `${label} record ${index} id is not valid UTF-8`, { label, index });
+    }
+    canonicalIdentifier(id, `${label} record ${index} id`);
+    cursor += idLength;
+    const inputBytes = stream.subarray(cursor, cursor + inputLength);
+    cursor += inputLength;
+    const nativeOutcome = stream.subarray(cursor, cursor + outcomeLength);
+    cursor += outcomeLength;
+    records.push(Object.freeze({
+      id,
+      operation: operationByte === 0 ? "execute" : "prepareInput",
+      input: parseKernelInput(inputBytes, `${id} PKI1`),
+      nativeOutcome,
+      kernelOutcome: null,
+    }));
+  }
+  if (cursor !== stream.length) {
+    fail("NATIVE_STREAM_INVALID", `${label} has trailing bytes`, { label, trailingBytes: stream.length - cursor });
+  }
+  return Object.freeze(records);
+}
+
+function validateNeedsCapacityOutcome(bytes, label) {
+  validateCanonicalOutcome(bytes, "NeedsCapacity", label);
+  const outcome = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const observed = Object.freeze({
+    minimumInputBytes: Number(outcome.readBigUInt64LE(32)),
+    minimumOutputBytes: Number(outcome.readBigUInt64LE(40)),
+    minimumScratchBytes: Number(outcome.readBigUInt64LE(48)),
+    minimumMemoryPages: Number(outcome.readBigUInt64LE(56)),
+  });
+  const expected = {
+    minimumInputBytes: NEEDS_CAPACITY_INPUT_BYTES,
+    minimumOutputBytes: 64,
+    minimumScratchBytes: 0,
+    minimumMemoryPages: EXPECTED_LIVE_PAGES,
+  };
+  if (Object.keys(expected).some((key) => observed[key] !== expected[key])) {
+    fail("NEEDS_CAPACITY_MISMATCH", `${label} does not contain the exact default-kernel requirement`, {
+      expected, observed,
+    });
+  }
+  return observed;
+}
+
+function outcomePrimary(bytes) {
+  const primaryLength = Number(bytes.readBigUInt64LE(12));
+  return bytes.subarray(32, 32 + primaryLength);
+}
+
+function outcomeSecondary(bytes) {
+  const primaryLength = Number(bytes.readBigUInt64LE(12));
+  const secondaryLength = Number(bytes.readBigUInt64LE(20));
+  return bytes.subarray(32 + primaryLength, 32 + primaryLength + secondaryLength);
+}
+
+export function validateRecordInventory(records) {
+  if (!Array.isArray(records) || records.length !== VECTOR_DESCRIPTORS.length) {
+    fail("VECTOR_INVENTORY_MISMATCH", "native stream inventory must contain exactly 20 vectors", {
+      expected: VECTOR_DESCRIPTORS.length, observed: records?.length,
+    });
+  }
+  for (let index = 0; index < VECTOR_DESCRIPTORS.length; index += 1) {
+    const expected = VECTOR_DESCRIPTORS[index];
+    const record = records[index];
+    if (record.id !== expected.id || record.operation !== expected.operation) {
+      fail("VECTOR_INVENTORY_MISMATCH", `native vector ${index} does not match the locked order`, {
+        expected: { id: expected.id, operation: expected.operation },
+        observed: { id: record.id, operation: record.operation },
+      });
+    }
+    if (record.input.instanceKind !== expected.instanceKind ||
+        record.input.effectResultPresent !== expected.effectResult) {
+      fail("VECTOR_INVENTORY_MISMATCH", `${record.id} input shape does not match the locked vector`, {
+        expectedInstanceKind: expected.instanceKind,
+        observedInstanceKind: record.input.instanceKind,
+        expectedEffectResult: expected.effectResult,
+        observedEffectResult: record.input.effectResultPresent,
+      });
+    }
+    validateCanonicalOutcome(record.nativeOutcome, expected.expectedKind, `${record.id} native outcome`);
+  }
+
+  const initialRequest = records[0].nativeOutcome;
+  const reconstructedRequest = records[1].nativeOutcome;
+  if (!initialRequest.equals(reconstructedRequest) ||
+      !records[1].input.instance.equals(outcomePrimary(initialRequest)) ||
+      !records[2].input.instance.equals(outcomePrimary(initialRequest)) ||
+      outcomeSecondary(initialRequest).length === 0) {
+    fail("VECTOR_RELATION_MISMATCH", "pending request reconstruction and typed resume do not share exact state/request bytes");
+  }
+
+  const capacity = records[19];
+  if (capacity.input.bytes.length !== NEEDS_CAPACITY_INPUT_BYTES ||
+      capacity.input.image.length !== NEEDS_CAPACITY_IMAGE_BYTES ||
+      sha256Hex(capacity.input.image) !== NEEDS_CAPACITY_IMAGE_SHA256 ||
+      capacity.input.instance.length !== NEEDS_CAPACITY_INSTANCE_BYTES ||
+      sha256Hex(capacity.input.instance) !== NEEDS_CAPACITY_INSTANCE_SHA256 ||
+      capacity.input.effectResult !== null) {
+    fail("NEEDS_CAPACITY_MISMATCH", "needs-capacity does not use the exact default-kernel preflight input", {
+      inputBytes: capacity.input.bytes.length,
+      imageBytes: capacity.input.image.length,
+      imageSha256: sha256Hex(capacity.input.image),
+      instanceBytes: capacity.input.instance.length,
+      instanceSha256: sha256Hex(capacity.input.instance),
+    });
+  }
+  validateNeedsCapacityOutcome(capacity.nativeOutcome, "needs-capacity native outcome");
+  if (sha256Hex(capacity.nativeOutcome) !== NEEDS_CAPACITY_OUTCOME_SHA256) {
+    fail("NEEDS_CAPACITY_MISMATCH", "needs-capacity native outcome digest changed", {
+      expected: NEEDS_CAPACITY_OUTCOME_SHA256,
+      observed: sha256Hex(capacity.nativeOutcome),
+    });
+  }
+  return records;
+}
+
+export function validateKernelModuleShape(module) {
+  const imports = WebAssembly.Module.imports(module);
+  if (imports.length !== 0) {
+    fail("KERNEL_IMPORTS_PRESENT", "Boundary Process kernel must be import-free", {
+      imports: imports.map(({ module: moduleName, name, kind }) => ({ module: moduleName, name, kind })),
+    });
+  }
+  const order = (entry) => `${entry.name}\0${entry.kind}`;
+  const observed = WebAssembly.Module.exports(module)
+    .map(({ name, kind }) => ({ name, kind }))
+    .sort((left, right) => order(left).localeCompare(order(right)));
+  const expected = REQUIRED_KERNEL_EXPORTS
+    .map(({ name, kind }) => ({ name, kind }))
+    .sort((left, right) => order(left).localeCompare(order(right)));
+  if (JSON.stringify(observed) !== JSON.stringify(expected)) {
+    fail("KERNEL_EXPORT_MISMATCH", "Boundary Process kernel export inventory is not exact", {
+      expected, observed,
+    });
+  }
+  return Object.freeze({ importCount: 0, exports: Object.freeze(observed) });
+}
+
+export function validateExactKernelBytes(bytes, label = "released kernel") {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength !== CORPUS_IDENTITY.boundary.kernelByteLength) {
+    fail("KERNEL_IDENTITY_MISMATCH", `${label} byte length does not match Boundary v1.7.0`, {
+      expected: CORPUS_IDENTITY.boundary.kernelByteLength, observed: bytes?.byteLength,
+    });
+  }
+  const digest = sha256Hex(bytes);
+  if (digest !== CORPUS_IDENTITY.boundary.kernelSha256) {
+    fail("KERNEL_IDENTITY_MISMATCH", `${label} digest does not match Boundary v1.7.0`, {
+      expected: CORPUS_IDENTITY.boundary.kernelSha256, observed: digest,
+    });
+  }
+  let module;
+  try {
+    module = new WebAssembly.Module(bytes);
+  } catch (error) {
+    fail("KERNEL_MODULE_INVALID", `${label} is not a valid WebAssembly module`, {
+      cause: error?.message ?? String(error),
+    });
+  }
+  validateKernelModuleShape(module);
+  return module;
+}
+
+export function assertByteIdenticalLocalKernel(releasedBytes, localBytes) {
+  if (!Buffer.from(releasedBytes).equals(Buffer.from(localBytes))) {
+    fail("LOCAL_KERNEL_MISMATCH", "locally rebuilt Process kernel differs from the exact released kernel", {
+      releasedSha256: sha256Hex(releasedBytes),
+      localSha256: sha256Hex(localBytes),
+      releasedByteLength: releasedBytes.byteLength,
+      localByteLength: localBytes.byteLength,
+    });
+  }
+}
+
+export function validateKernelPair(releasedBytes, localBytes) {
+  const releasedModule = validateExactKernelBytes(releasedBytes, "released kernel");
+  validateExactKernelBytes(localBytes, "locally rebuilt kernel");
+  assertByteIdenticalLocalKernel(releasedBytes, localBytes);
+  return releasedModule;
+}
+
+function exactWasmU64(value, label) {
+  if (typeof value === "bigint") {
+    if (value < 0n || value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      fail("KERNEL_OUTPUT_INVALID", `${label} is not an exact safe integer`, { label, value: String(value) });
+    }
+    return Number(value);
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    fail("KERNEL_OUTPUT_INVALID", `${label} is not a nonnegative integer`, { label, value });
+  }
+  return value >>> 0 === value ? value : value;
+}
+
+function memoryRange(exports, pointerValue, lengthValue, label) {
+  const pointer = pointerValue >>> 0;
+  const length = exactWasmU64(lengthValue, `${label} length`);
+  const memory = new Uint8Array(exports.memory.buffer);
+  if (pointer > memory.length || length > memory.length - pointer) {
+    fail("KERNEL_OUTPUT_INVALID", `${label} lies outside exported memory`, { pointer, length, memory: memory.length });
+  }
+  return memory.subarray(pointer, pointer + length);
+}
+
+function kernelOutput(exports) {
+  return Buffer.from(memoryRange(
+    exports,
+    exports.boundary_process_kernel_output_ptr(),
+    exports.boundary_process_kernel_output_len(),
+    "kernel output",
+  ));
+}
+
+function kernelError(exports) {
+  return Buffer.from(memoryRange(
+    exports,
+    exports.boundary_process_kernel_error_ptr(),
+    exports.boundary_process_kernel_error_len(),
+    "kernel error",
+  )).toString("utf8");
+}
+
+export function validateInstanceIdentity(exports, label) {
+  if (exports.boundary_process_kernel_abi_version() !== CORPUS_IDENTITY.boundary.processKernelAbiVersion) {
+    fail("KERNEL_ABI_MISMATCH", `${label} does not expose Process kernel ABI 1`, { label });
+  }
+}
+
+function instantiateFresh(module, label) {
+  const instance = new WebAssembly.Instance(module, {});
+  validateInstanceIdentity(instance.exports, label);
+  return instance;
+}
+
+function executeEncodedRecord(module, record) {
+  const instance = instantiateFresh(module, record.id);
+  const exports = instance.exports;
+  if (exports.boundary_process_kernel_reserve(BigInt(record.input.bytes.length)) !== 1) {
+    fail("KERNEL_VECTOR_REJECTED", `${record.id} encoded input was not admitted`);
+  }
+  const inputPointer = exports.boundary_process_kernel_input_ptr() >>> 0;
+  let memory = new Uint8Array(exports.memory.buffer);
+  if (inputPointer > memory.length || record.input.bytes.length > memory.length - inputPointer) {
+    fail("KERNEL_MEMORY_INVALID", `${record.id} input arena is outside exported memory`);
+  }
+  memory.set(record.input.bytes, inputPointer);
+  const status = exports.boundary_process_kernel_execute(record.input.bytes.length);
+  if (status !== 0) {
+    fail("KERNEL_VECTOR_REJECTED", `${record.id} was rejected by the released kernel`, {
+      status, error: kernelError(exports),
+    });
+  }
+  if (exactWasmU64(exports.boundary_process_kernel_error_len(), `${record.id} error length`) !== 0) {
+    fail("KERNEL_VECTOR_REJECTED", `${record.id} left a kernel error after success`, {
+      error: kernelError(exports),
+    });
+  }
+  return Object.freeze({ instance, outcome: kernelOutput(exports) });
+}
+
+function capacityInstanceFacts(instance) {
+  const exports = instance.exports;
+  const livePages = exports.memory.buffer.byteLength / 65_536;
+  const occupiedBytesValue = exports.boundary_process_kernel_occupied_memory_bytes();
+  const occupiedBytes = typeof occupiedBytesValue === "bigint"
+    ? occupiedBytesValue
+    : BigInt(occupiedBytesValue >>> 0);
+  const inputCapacity = exports.boundary_process_kernel_input_capacity();
+  if (livePages !== EXPECTED_LIVE_PAGES || occupiedBytes !== EXPECTED_OCCUPIED_BYTES ||
+      inputCapacity !== DEFAULT_INPUT_CAPACITY) {
+    fail("KERNEL_CAPACITY_PROBE_MISMATCH", "released kernel capacity projection changed", {
+      expected: {
+        livePages: EXPECTED_LIVE_PAGES,
+        occupiedBytes: String(EXPECTED_OCCUPIED_BYTES),
+        inputCapacity: DEFAULT_INPUT_CAPACITY,
+      },
+      observed: { livePages, occupiedBytes: String(occupiedBytes), inputCapacity },
+    });
+  }
+  return Object.freeze({ livePages, occupiedBytes, inputCapacity });
+}
+
+function executeCapacityRecord(instance, record) {
+  const exports = instance.exports;
+  const inputPointer = exports.boundary_process_kernel_input_ptr() >>> 0;
+  const inputCapacity = exports.boundary_process_kernel_input_capacity();
+  const before = memoryRange(exports, inputPointer, inputCapacity, "kernel input arena");
+  const beforeDigest = sha256Hex(before);
+  const prepared = exports.boundary_process_kernel_prepare_input(
+    0,
+    BigInt(record.input.image.length),
+    BigInt(record.input.instance.length),
+    0,
+    0n,
+  );
+  if (prepared !== 0) {
+    fail("NEEDS_CAPACITY_MISMATCH", "default kernel admitted the oversized vector", { prepared });
+  }
+  const after = memoryRange(exports, inputPointer, inputCapacity, "kernel input arena");
+  if (sha256Hex(after) !== beforeDigest) {
+    fail("NEEDS_CAPACITY_MISMATCH", "prepare_input changed the guest input arena before capacity admission");
+  }
+  if (exactWasmU64(exports.boundary_process_kernel_error_len(), "needs-capacity error length") !== 0) {
+    fail("NEEDS_CAPACITY_MISMATCH", "prepare_input returned a kernel error", { error: kernelError(exports) });
+  }
+  const outcome = kernelOutput(exports);
+  if (outcome.length !== 64) {
+    fail("NEEDS_CAPACITY_MISMATCH", "prepare_input did not return a 64-byte NeedsCapacity outcome", {
+      observed: outcome.length,
+    });
+  }
+  validateNeedsCapacityOutcome(outcome, "needs-capacity kernel outcome");
+  return outcome;
+}
+
+function runEmitterToFile(executable, argumentsList, outputPath, label) {
+  const output = fs.openSync(outputPath, "wx", 0o600);
+  let result;
+  try {
+    result = childProcess.spawnSync(executable, argumentsList, {
+      stdio: ["ignore", output, "pipe"],
+      encoding: "utf8",
+      maxBuffer: 1024 * 1024,
+      timeout: SUBPROCESS_TIMEOUT_MS,
+      killSignal: "SIGKILL",
+    });
+  } finally {
+    fs.closeSync(output);
+  }
+  if (result.error || result.status !== 0) {
+    fail("NATIVE_EMITTER_FAILED", `${label} failed`, {
+      status: result.status,
+      cause: result.error?.message ?? null,
+      stderr: result.stderr?.slice(0, 16_384) ?? "",
+    });
+  }
+  const stat = fs.statSync(outputPath);
+  if (!stat.isFile() || stat.size === 0 || stat.size > MAX_NATIVE_STREAM_BYTES) {
+    fail("NATIVE_STREAM_INVALID", `${label} emitted an invalid stream length`, {
+      byteLength: stat.size, maximum: MAX_NATIVE_STREAM_BYTES,
+    });
+  }
+  return fs.readFileSync(outputPath);
+}
+
+function assertOutcomeParity(id, nativeOutcome, kernelOutcome) {
+  if (!(kernelOutcome instanceof Uint8Array) ||
+      !Buffer.from(nativeOutcome).equals(Buffer.from(kernelOutcome))) {
+    fail("CORPUS_PARITY_MISMATCH", `${id} native and released-kernel outcomes differ`, {
+      id,
+      nativeSha256: sha256Hex(nativeOutcome),
+      kernelSha256: kernelOutcome instanceof Uint8Array ? sha256Hex(kernelOutcome) : null,
+    });
+  }
+}
+
+const verifiedParityBrand = Symbol("verified Boundary native/kernel parity");
+
+function verifyParityRecords(records) {
+  validateRecordInventory(records);
+  for (const record of records) {
+    assertOutcomeParity(record.id, record.nativeOutcome, record.kernelOutcome);
+  }
+  return Object.freeze({
+    [verifiedParityBrand]: true,
+    records: Object.freeze([...records]),
+  });
+}
+
+function constructCorpusFromVerifiedParity(
+  verified,
+  { onArtifactConstruction = () => {} } = {},
+) {
+  if (verified?.[verifiedParityBrand] !== true) {
+    fail("CORPUS_PARITY_MISMATCH", "artifact construction requires verified native/kernel parity");
+  }
+  const records = verified.records;
+
+  const artifacts = [];
+  const payloadParts = [];
+  const vectors = [];
+  let offset = 0;
+  const addArtifact = (id, bytes) => {
+    onArtifactConstruction(id);
+    const owned = Buffer.from(bytes);
+    artifacts.push({ id, offset, byteLength: owned.length, sha256: sha256Hex(owned) });
+    payloadParts.push(owned);
+    offset += owned.length;
+  };
+
+  for (let index = 0; index < VECTOR_DESCRIPTORS.length; index += 1) {
+    const expected = VECTOR_DESCRIPTORS[index];
+    const record = records[index];
+    const imageId = `${expected.id}.image`;
+    const instanceId = `${expected.id}.instance`;
+    const effectResultId = expected.effectResult ? `${expected.id}.effect-result` : null;
+    const outcomeId = `${expected.id}.outcome`;
+    addArtifact(imageId, record.input.image);
+    addArtifact(instanceId, record.input.instance);
+    if (effectResultId !== null) addArtifact(effectResultId, record.input.effectResult);
+    addArtifact(outcomeId, record.nativeOutcome);
+    const outcomeSha256 = sha256Hex(record.nativeOutcome);
+    vectors.push({
+      id: expected.id,
+      scenarios: [...expected.scenarios],
+      image: imageId,
+      instance: { kind: expected.instanceKind, artifact: instanceId },
+      effectResult: effectResultId,
+      expectedOutcome: outcomeId,
+      expectedKind: expected.expectedKind,
+      nativeOutcomeSha256: outcomeSha256,
+      kernelOutcomeSha256: sha256Hex(record.kernelOutcome),
+    });
+  }
+  if (artifacts.length !== EXPECTED_ARTIFACT_IDS.length) {
+    fail("CORPUS_CONSTRUCTION_INVALID", "artifact construction did not produce exactly 61 records", {
+      observed: artifacts.length,
+    });
+  }
+  const payloadBytes = Buffer.concat(payloadParts, offset);
+  const manifest = {
+    format: CORPUS_IDENTITY.manifestFormat,
+    producer: { ...CORPUS_IDENTITY.producer },
+    boundary: { ...CORPUS_IDENTITY.boundary },
+    payload: {
+      assetName: CORPUS_IDENTITY.payloadAssetName,
+      sha256: sha256Hex(payloadBytes),
+      byteLength: payloadBytes.length,
+    },
+    artifacts,
+    vectors,
+    receipt: { ...CORPUS_IDENTITY.receipt },
+  };
+  const manifestBytes = canonicalJsonBytes(manifest);
+  validateCorpusBytes(manifestBytes, payloadBytes);
+  return Object.freeze({ manifest, manifestBytes, payloadBytes });
+}
+
+export function buildCorpusFromParityRecords(records, options = {}) {
+  return constructCorpusFromVerifiedParity(verifyParityRecords(records), options);
+}
+
+async function generateWorker({ kernelBytes, vectorEmitter, capacityEmitter, directory }) {
+  const module = new WebAssembly.Module(kernelBytes);
+  validateKernelModuleShape(module);
+
+  const mainStreamPath = path.join(directory, "native-main.bpcgen");
+  const mainRecords = parseNativeStream(
+    runEmitterToFile(
+      vectorEmitter,
+      ["--conformance-corpus-v1"],
+      mainStreamPath,
+      "Boundary Process native vector emitter",
+    ),
+    "main native vector stream",
+  );
+  if (mainRecords.length !== 19 || mainRecords.some((record, index) => record.id !== VECTOR_DESCRIPTORS[index].id)) {
+    fail("VECTOR_INVENTORY_MISMATCH", "main native emitter did not produce exact vectors 0 through 18");
+  }
+
+  const records = [];
+  let freshVectorInstanceCount = 0;
+  for (const record of mainRecords) {
+    const { outcome } = executeEncodedRecord(module, record);
+    freshVectorInstanceCount += 1;
+    assertOutcomeParity(record.id, record.nativeOutcome, outcome);
+    records.push(Object.freeze({ ...record, kernelOutcome: outcome }));
+  }
+
+  // Vector 19's own fresh instance supplies the physical probe values. It is not
+  // an admission-only extra instance and it is never used for another vector.
+  const capacityInstance = instantiateFresh(module, "needs-capacity");
+  freshVectorInstanceCount += 1;
+  const facts = capacityInstanceFacts(capacityInstance);
+  const capacityStreamPath = path.join(directory, "native-capacity.bpcgen");
+  const capacityRecords = parseNativeStream(
+    runEmitterToFile(
+      capacityEmitter,
+      [
+        "--conformance-corpus-v1",
+        String(facts.livePages),
+        String(facts.occupiedBytes),
+        String(facts.inputCapacity),
+      ],
+      capacityStreamPath,
+      "Boundary Process native capacity emitter",
+    ),
+    "capacity native vector stream",
+  );
+  if (capacityRecords.length !== 1 || capacityRecords[0].id !== "needs-capacity") {
+    fail("VECTOR_INVENTORY_MISMATCH", "capacity emitter did not produce only needs-capacity");
+  }
+  const capacityOutcome = executeCapacityRecord(capacityInstance, capacityRecords[0]);
+  assertOutcomeParity(capacityRecords[0].id, capacityRecords[0].nativeOutcome, capacityOutcome);
+  records.push(Object.freeze({ ...capacityRecords[0], kernelOutcome: capacityOutcome }));
+  if (freshVectorInstanceCount !== VECTOR_DESCRIPTORS.length) {
+    fail("FRESH_INSTANCE_COUNT_MISMATCH", "corpus generation did not use one fresh instance per vector", {
+      expected: VECTOR_DESCRIPTORS.length,
+      observed: freshVectorInstanceCount,
+    });
+  }
+
+  const corpus = buildCorpusFromParityRecords(records);
+  fs.writeFileSync(path.join(directory, CORPUS_IDENTITY.manifestAssetName), corpus.manifestBytes, { flag: "wx" });
+  fs.writeFileSync(path.join(directory, CORPUS_IDENTITY.payloadAssetName), corpus.payloadBytes, { flag: "wx" });
+  return Object.freeze({ ...corpus, freshVectorInstanceCount });
+}
+
+const verifiedDeterminismBrand = Symbol("verified independent corpus rebuilds");
+
+export function assertDeterministic(first, second) {
+  if (first.freshVectorInstanceCount !== VECTOR_DESCRIPTORS.length ||
+      second.freshVectorInstanceCount !== VECTOR_DESCRIPTORS.length) {
+    fail("FRESH_INSTANCE_COUNT_MISMATCH", "independent rebuilds did not observe 20 fresh instances each");
+  }
+  if (!first.manifestBytes.equals(second.manifestBytes) ||
+      !first.payloadBytes.equals(second.payloadBytes)) {
+    fail("CORPUS_NONDETERMINISTIC", "independent corpus rebuilds are not byte-identical", {
+      firstManifestSha256: sha256Hex(first.manifestBytes),
+      secondManifestSha256: sha256Hex(second.manifestBytes),
+      firstPayloadSha256: sha256Hex(first.payloadBytes),
+      secondPayloadSha256: sha256Hex(second.payloadBytes),
+    });
+  }
+  return Object.freeze({
+    [verifiedDeterminismBrand]: true,
+    first,
+    second,
+  });
+}
+
+function apiHeaders(accept = "application/vnd.github+json") {
+  const headers = {
+    Accept: accept,
+    "User-Agent": "boundary-process-v1-conformance-builder",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+async function fetchChecked(fetchImpl, url, accept = "application/vnd.github+json") {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      headers: apiHeaders(accept),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (error) {
+    fail("RELEASE_ACQUISITION_FAILED", `failed to fetch ${url}`, {
+      url, cause: error?.message ?? String(error),
+    });
+  }
+  if (!response.ok) {
+    fail("RELEASE_ACQUISITION_FAILED", `fetch returned HTTP ${response.status}`, {
+      url, status: response.status,
+    });
+  }
+  return response;
+}
+
+async function fetchJson(fetchImpl, url) {
+  return (await fetchChecked(fetchImpl, url)).json();
+}
+
+export async function resolveReleaseTagCommit(fetchImpl = fetch) {
+  let object = (
+    await fetchJson(
+      fetchImpl,
+      `https://api.github.com/repos/${CORPUS_IDENTITY.producer.repository}/git/ref/tags/${CORPUS_IDENTITY.producer.releaseTag}`,
+    )
+  ).object;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (!object || typeof object.sha !== "string" || typeof object.type !== "string") {
+      fail("RELEASE_TAG_INVALID", "v1.7.0 tag metadata is malformed");
+    }
+    if (object.type === "commit") {
+      if (object.sha !== CORPUS_IDENTITY.producer.commit) {
+        fail("RELEASE_TAG_DRIFT", "Boundary v1.7.0 tag target changed", {
+          expected: CORPUS_IDENTITY.producer.commit, observed: object.sha,
+        });
+      }
+      return object.sha;
+    }
+    if (object.type !== "tag") {
+      fail("RELEASE_TAG_INVALID", "v1.7.0 tag does not resolve to a commit", { type: object.type });
+    }
+    object = (
+      await fetchJson(
+        fetchImpl,
+        `https://api.github.com/repos/${CORPUS_IDENTITY.producer.repository}/git/tags/${object.sha}`,
+      )
+    ).object;
+  }
+  fail("RELEASE_TAG_INVALID", "v1.7.0 tag indirection is too deep");
+}
+
+export async function acquireReleasedKernel(fetchImpl = fetch) {
+  await resolveReleaseTagCommit(fetchImpl);
+  const release = await fetchJson(
+    fetchImpl,
+    `https://api.github.com/repos/${CORPUS_IDENTITY.producer.repository}/releases/tags/${CORPUS_IDENTITY.producer.releaseTag}`,
+  );
+  if (release?.tag_name !== CORPUS_IDENTITY.producer.releaseTag || !Array.isArray(release.assets)) {
+    fail("RELEASE_METADATA_INVALID", "Boundary v1.7.0 release metadata is malformed");
+  }
+  const assets = release.assets.filter((asset) => asset?.name === KERNEL_ASSET_NAME);
+  if (assets.length !== 1) {
+    fail("RELEASE_METADATA_INVALID", "Boundary v1.7.0 must contain exactly one fixed Process kernel asset", {
+      observed: assets.length,
+    });
+  }
+  const asset = assets[0];
+  if (asset.size !== CORPUS_IDENTITY.boundary.kernelByteLength) {
+    fail("RELEASE_ASSET_LENGTH_MISMATCH", "release API kernel byte length does not match Boundary v1.7.0", {
+      expected: CORPUS_IDENTITY.boundary.kernelByteLength, observed: asset.size,
+    });
+  }
+  const expectedApiDigest = `sha256:${CORPUS_IDENTITY.boundary.kernelSha256}`;
+  if (asset.digest !== expectedApiDigest) {
+    fail("RELEASE_ASSET_DIGEST_MISMATCH", "release API kernel digest does not match Boundary v1.7.0", {
+      expected: expectedApiDigest, observed: asset.digest ?? null,
+    });
+  }
+  if (typeof asset.browser_download_url !== "string") {
+    fail("RELEASE_METADATA_INVALID", "release API kernel download URL is missing");
+  }
+  const response = await fetchChecked(fetchImpl, asset.browser_download_url, "application/octet-stream");
+  const bytes = Buffer.from(await response.arrayBuffer());
+  validateExactKernelBytes(bytes, "downloaded released kernel");
+  return bytes;
+}
+
+function readRegularBounded(file, maximum, label) {
+  const stat = fs.statSync(file);
+  if (!stat.isFile() || stat.size <= 0 || stat.size > maximum) {
+    fail("INPUT_FILE_INVALID", `${label} must be a bounded regular file`, {
+      file, byteLength: stat.size, maximum,
+    });
+  }
+  return fs.readFileSync(file);
+}
+
+export function validateWorldContractModule(module, manifestBytes, payloadBytes) {
+  for (const name of [
+    "parseManifestBytes", "validateBoundaryProcessCorpusManifest", "validateBundlePayload",
+  ]) {
+    if (typeof module[name] !== "function") {
+      fail("WORLD_CONTRACT_REJECTED", `pinned World validator does not export ${name}`);
+    }
+  }
+  try {
+    const parsed = module.parseManifestBytes(new Uint8Array(manifestBytes));
+    const validated = module.validateBoundaryProcessCorpusManifest(parsed);
+    module.validateBundlePayload(validated, new Uint8Array(payloadBytes));
+  } catch (error) {
+    fail("WORLD_CONTRACT_REJECTED", "pinned World validator rejected the Boundary corpus", {
+      cause: error?.message ?? String(error),
+      code: error?.code ?? null,
+    });
+  }
+  return true;
+}
+
+export function assertFileBelongsToCommit(repository, commit, relative, source) {
+  const committed = childProcess.spawnSync(
+    "git",
+    ["-C", repository, "show", `${commit}:${relative}`],
+    { encoding: null, maxBuffer: 4 * 1024 * 1024, timeout: 10_000 },
+  );
+  if (committed.error || committed.status !== 0 ||
+      !Buffer.from(committed.stdout).equals(source)) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "validator bytes do not belong to the claimed commit", {
+      commit,
+      relative,
+    });
+  }
+}
+
+export function validateWorldSourceIdentity(options) {
+  const supplied = [options.worldValidator, options.worldCommit, options.worldValidatorSha256];
+  if (supplied.some((value) => value === undefined)) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "World validator path, commit, and SHA-256 must be supplied together");
+  }
+  if (!COMMIT_PATTERN.test(options.worldCommit) || !DIGEST_PATTERN.test(options.worldValidatorSha256)) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "World validator commit or SHA-256 is malformed");
+  }
+  if (options.worldCommit !== WORLD_VALIDATOR_COMMIT ||
+      options.worldValidatorSha256 !== WORLD_VALIDATOR_SHA256) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "World validator identity differs from the pinned PR 47 source", {
+      expectedCommit: WORLD_VALIDATOR_COMMIT,
+      observedCommit: options.worldCommit,
+      expectedSha256: WORLD_VALIDATOR_SHA256,
+      observedSha256: options.worldValidatorSha256,
+    });
+  }
+  const source = readRegularBounded(options.worldValidator, 4 * 1024 * 1024, "World validator");
+  const observedDigest = sha256Hex(source);
+  if (observedDigest !== options.worldValidatorSha256) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "World validator digest does not match the pinned value", {
+      expected: options.worldValidatorSha256, observed: observedDigest,
+    });
+  }
+  const worldRoot = path.dirname(path.dirname(path.resolve(options.worldValidator)));
+  const observedCommit = childProcess.spawnSync("git", ["-C", worldRoot, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  if (observedCommit.status !== 0 || observedCommit.stdout.trim() !== options.worldCommit) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "World validator checkout is not the pinned commit", {
+      expected: options.worldCommit,
+      observed: observedCommit.status === 0 ? observedCommit.stdout.trim() : null,
+    });
+  }
+  const validatorRelative = path.relative(worldRoot, path.resolve(options.worldValidator));
+  if (validatorRelative !== WORLD_VALIDATOR_RELATIVE) {
+    fail("WORLD_VALIDATOR_IDENTITY_INVALID", "World validator has the wrong repository-relative path", {
+      validator: options.worldValidator,
+      expected: WORLD_VALIDATOR_RELATIVE,
+      observed: validatorRelative,
+    });
+  }
+  assertFileBelongsToCommit(worldRoot, options.worldCommit, validatorRelative, source);
+  return Object.freeze({ source, observedDigest });
+}
+
+async function validateWithWorld(options, manifestBytes, payloadBytes) {
+  const supplied = [options.worldValidator, options.worldCommit, options.worldValidatorSha256];
+  if (supplied.every((value) => value === undefined)) return false;
+  const { observedDigest } = validateWorldSourceIdentity(options);
+  let module;
+  try {
+    module = await import(`${pathToFileURL(path.resolve(options.worldValidator)).href}?sha256=${observedDigest}`);
+  } catch (error) {
+    fail("WORLD_CONTRACT_REJECTED", "could not load the pinned World validator", {
+      cause: error?.message ?? String(error),
+    });
+  }
+  return validateWorldContractModule(module, manifestBytes, payloadBytes);
+}
+
+function runGit(argumentsList, label, cwd = process.cwd()) {
+  const result = childProcess.spawnSync("git", argumentsList, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 10_000,
+  });
+  if (result.error || result.status !== 0) {
+    fail("GENERATOR_IDENTITY_INVALID", `could not ${label}`, {
+      status: result.status,
+      cause: result.error?.message ?? null,
+      stderr: result.stderr?.slice(0, 16_384) ?? "",
+    });
+  }
+  return result.stdout;
+}
+
+export function generatorSourceIdentity(expectedCommit = undefined) {
+  const repository = runGit(["rev-parse", "--show-toplevel"], "resolve generator repository").trim();
+  const head = runGit(["rev-parse", "--verify", "HEAD^{commit}"], "resolve generator HEAD", repository).trim();
+  if (!COMMIT_PATTERN.test(head) ||
+      (expectedCommit !== undefined && expectedCommit !== head)) {
+    fail("GENERATOR_IDENTITY_INVALID", "generator commit does not equal the current repository HEAD", {
+      expected: expectedCommit ?? head,
+      observed: head,
+    });
+  }
+  const status = runGit(
+    ["status", "--porcelain=v1", "--untracked-files=all"],
+    "inspect generator source state",
+    repository,
+  ).trim();
+  const digestState = crypto.createHash("sha256");
+  for (const sourcePath of GENERATOR_SOURCE_PATHS) {
+    const absolute = path.join(repository, sourcePath);
+    const bytes = readRegularBounded(absolute, 4 * 1024 * 1024, `generator source ${sourcePath}`);
+    digestState.update(sourcePath);
+    digestState.update("\0");
+    digestState.update(String(bytes.length));
+    digestState.update("\0");
+    digestState.update(bytes);
+    if (status.length === 0) {
+      const committed = childProcess.spawnSync(
+        "git",
+        ["show", `${head}:${sourcePath}`],
+        { cwd: repository, encoding: null, maxBuffer: 4 * 1024 * 1024, timeout: 10_000 },
+      );
+      if (committed.error || committed.status !== 0 || !Buffer.from(committed.stdout).equals(bytes)) {
+        fail("GENERATOR_IDENTITY_INVALID", "clean generator source does not match its commit", {
+          commit: head,
+          sourcePath,
+        });
+      }
+    }
+  }
+  return Object.freeze({
+    generatorCommit: status.length === 0 ? head : null,
+    generatorBaseCommit: head,
+    generatorSourceSha256: digestState.digest("hex"),
+    generatorWorktreeClean: status.length === 0,
+  });
+}
+
+export function installDirectoryAtomic(destination, files) {
+  const requested = path.resolve(destination);
+  const parent = path.dirname(requested);
+  const base = path.basename(requested);
+  const parentStat = fs.lstatSync(parent);
+  if (!parentStat.isDirectory()) {
+    fail("OUTPUT_DESTINATION_INVALID", "corpus output parent must be a directory", {
+      destination: requested,
+    });
+  }
+  const absolute = path.join(fs.realpathSync(parent), base);
+  const root = path.parse(absolute).root;
+  const repository = path.resolve(".");
+  const home = path.resolve(os.homedir());
+  const contains = (ancestor, child) => {
+    const relative = path.relative(ancestor, child);
+    return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+  };
+  if (absolute === root || contains(absolute, repository) || contains(absolute, home)) {
+    fail("OUTPUT_DESTINATION_INVALID", "corpus output destination is too broad", {
+      destination: absolute,
+    });
+  }
+  const staging = fs.mkdtempSync(path.join(path.dirname(absolute), `.${base}.staging-`));
+  let backup = null;
+  try {
+    for (const [name, bytes] of files) {
+      fs.writeFileSync(path.join(staging, name), bytes, { flag: "wx", mode: 0o644 });
+    }
+    if (fs.existsSync(absolute)) {
+      const stat = fs.lstatSync(absolute);
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        fail("OUTPUT_DESTINATION_INVALID", "corpus output destination is not a real directory", { destination: absolute });
+      }
+      const observed = fs.readdirSync(absolute).sort();
+      const expected = [...files.keys()].sort();
+      if (observed.length !== 0) {
+        if (JSON.stringify(observed) !== JSON.stringify(expected)) {
+          fail("OUTPUT_DESTINATION_CONFLICT", "existing corpus output inventory differs", {
+            destination: absolute,
+            expected,
+            observed,
+          });
+        }
+        let identical = true;
+        for (const [name, bytes] of files) {
+          const existing = path.join(absolute, name);
+          const existingStat = fs.lstatSync(existing);
+          if (!existingStat.isFile() || existingStat.isSymbolicLink()) {
+            fail("OUTPUT_DESTINATION_CONFLICT", `existing corpus output ${name} is not one regular file`, {
+              destination: absolute,
+              name,
+            });
+          }
+          identical &&= fs.readFileSync(existing).equals(bytes);
+        }
+        if (identical) {
+          fs.rmSync(staging, { recursive: true, force: true });
+          return;
+        }
+        try {
+          validateCorpusBytes(
+            fs.readFileSync(path.join(absolute, CORPUS_IDENTITY.manifestAssetName)),
+            fs.readFileSync(path.join(absolute, CORPUS_IDENTITY.payloadAssetName)),
+          );
+          const priorReceipt = JSON.parse(fs.readFileSync(
+            path.join(absolute, "boundary-process-v1-conformance-generation-receipt.json"),
+            "utf8",
+          ));
+          if (priorReceipt?.format !== "boundary-process-v1-conformance-generation-receipt/v1") {
+            throw new Error("wrong receipt format");
+          }
+        } catch (error) {
+          fail("OUTPUT_DESTINATION_CONFLICT", "existing corpus output is not generator-owned", {
+            destination: absolute,
+            cause: error?.message ?? String(error),
+          });
+        }
+        backup = fs.mkdtempSync(path.join(path.dirname(absolute), `.${base}.backup-`));
+        fs.rmdirSync(backup);
+        fs.renameSync(absolute, backup);
+      }
+    }
+    fs.renameSync(staging, absolute);
+    if (backup !== null) {
+      try {
+        fs.rmSync(backup, { recursive: true, force: true });
+      } catch {
+        // The new exact directory is already committed. A stale owned backup is
+        // cleanup debt, not a failed publication of local build outputs.
+      }
+    }
+  } catch (error) {
+    if (fs.existsSync(staging)) {
+      try {
+        fs.rmSync(staging, { recursive: true, force: true });
+      } catch {}
+    }
+    if (backup !== null && !fs.existsSync(absolute)) {
+      try {
+        fs.renameSync(backup, absolute);
+      } catch {}
+    }
+    if (error instanceof CorpusBuildError) throw error;
+    fail("OUTPUT_INSTALL_FAILED", "failed to install corpus output atomically", {
+      destination: absolute, cause: error?.message ?? String(error),
+    });
+  }
+}
+
+function parseOptions(argv) {
+  const options = {};
+  const allowed = new Set([
+    "--kernel", "--local-kernel", "--vector-emitter", "--capacity-emitter",
+    "--output-dir", "--generator-commit", "--world-validator", "--world-commit",
+    "--world-validator-sha256",
+  ]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.has(name) || value === undefined || value.length === 0 || Object.hasOwn(options, name.slice(2))) {
+      fail("CORPUS_USAGE", `invalid or duplicate argument ${name ?? "<missing>"}`);
+    }
+    options[name.slice(2).replaceAll(/-([a-z])/g, (_, letter) => letter.toUpperCase())] = value;
+  }
+  for (const name of ["localKernel", "vectorEmitter", "capacityEmitter", "outputDir"]) {
+    if (options[name] === undefined) fail("CORPUS_USAGE", `missing --${name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`);
+  }
+  return options;
+}
+
+export async function buildProcessConformanceCorpus(options) {
+  const releasedBytes = options.kernel === undefined
+    ? await acquireReleasedKernel()
+    : readRegularBounded(options.kernel, MAX_KERNEL_BYTES, "released kernel override");
+  const localBytes = readRegularBounded(options.localKernel, MAX_KERNEL_BYTES, "locally rebuilt kernel");
+  validateKernelPair(releasedBytes, localBytes);
+  if (options.generatorCommit !== undefined && !COMMIT_PATTERN.test(options.generatorCommit)) {
+    fail("GENERATOR_IDENTITY_INVALID", "generator commit must be a lowercase 40-byte Git commit");
+  }
+  const generatorIdentity = generatorSourceIdentity(options.generatorCommit);
+
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "boundary-process-v1-corpus-"));
+  try {
+    const firstDirectory = path.join(temporary, "worker-1");
+    const secondDirectory = path.join(temporary, "worker-2");
+    fs.mkdirSync(firstDirectory);
+    fs.mkdirSync(secondDirectory);
+    const first = await generateWorker({
+      kernelBytes: releasedBytes,
+      vectorEmitter: options.vectorEmitter,
+      capacityEmitter: options.capacityEmitter,
+      directory: firstDirectory,
+    });
+    const second = await generateWorker({
+      kernelBytes: releasedBytes,
+      vectorEmitter: options.vectorEmitter,
+      capacityEmitter: options.capacityEmitter,
+      directory: secondDirectory,
+    });
+    const deterministic = assertDeterministic(first, second);
+    if (deterministic[verifiedDeterminismBrand] !== true) {
+      fail("CORPUS_NONDETERMINISTIC", "finalization requires verified independent rebuilds");
+    }
+    const finalBuild = deterministic.first;
+    const worldContractValidated = await validateWithWorld(
+      options,
+      finalBuild.manifestBytes,
+      finalBuild.payloadBytes,
+    );
+    const receipt = {
+      format: "boundary-process-v1-conformance-generation-receipt/v1",
+      result: generatorIdentity.generatorWorktreeClean && worldContractValidated
+        ? "passed"
+        : "candidate",
+      semanticProducerCommit: CORPUS_IDENTITY.producer.commit,
+      ...generatorIdentity,
+      kernelSha256: CORPUS_IDENTITY.boundary.kernelSha256,
+      kernelByteLength: CORPUS_IDENTITY.boundary.kernelByteLength,
+      kernelImportCount: 0,
+      kernelAbiVersion: CORPUS_IDENTITY.boundary.processKernelAbiVersion,
+      vectorCount: VECTOR_DESCRIPTORS.length,
+      nativeKernelParityCount: VECTOR_DESCRIPTORS.length,
+      artifactCount: EXPECTED_ARTIFACT_IDS.length,
+      manifestSha256: sha256Hex(finalBuild.manifestBytes),
+      manifestByteLength: finalBuild.manifestBytes.length,
+      payloadSha256: sha256Hex(finalBuild.payloadBytes),
+      payloadByteLength: finalBuild.payloadBytes.length,
+      freshVectorInstanceCount: finalBuild.freshVectorInstanceCount,
+      deterministicRebuild: true,
+      worldContractValidated,
+      ...(worldContractValidated ? {
+        worldValidatorCommit: options.worldCommit,
+        worldValidatorSha256: options.worldValidatorSha256,
+      } : {}),
+    };
+    const receiptBytes = canonicalJsonBytes(receipt);
+    installDirectoryAtomic(options.outputDir, new Map([
+      [CORPUS_IDENTITY.manifestAssetName, finalBuild.manifestBytes],
+      [CORPUS_IDENTITY.payloadAssetName, finalBuild.payloadBytes],
+      ["boundary-process-v1-conformance-generation-receipt.json", receiptBytes],
+    ]));
+    return Object.freeze({
+      receipt,
+      receiptBytes,
+      manifestBytes: finalBuild.manifestBytes,
+      payloadBytes: finalBuild.payloadBytes,
+    });
+  } finally {
+    try {
+      fs.rmSync(temporary, { recursive: true, force: true });
+    } catch {
+      // Output installation is the commit point. A temporary cleanup failure
+      // must not turn a committed exact directory into an ambiguous failure.
+    }
+  }
+}
+
+export function buildErrorRecord(error) {
+  if (error instanceof CorpusBuildError) {
+    return { ok: false, code: error.code, message: error.message, details: error.details };
+  }
+  return {
+    ok: false,
+    code: "CORPUS_BUILD_FAILED",
+    message: error?.message ?? String(error),
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseOptions(argv);
+  const result = await buildProcessConformanceCorpus(options);
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    format: "boundary-process-v1-conformance-build-result/v1",
+    outputDirectory: path.resolve(options.outputDir),
+    manifestSha256: result.receipt.manifestSha256,
+    manifestByteLength: result.receipt.manifestByteLength,
+    payloadSha256: result.receipt.payloadSha256,
+    payloadByteLength: result.receipt.payloadByteLength,
+    vectorCount: result.receipt.vectorCount,
+    artifactCount: result.receipt.artifactCount,
+    deterministicRebuild: result.receipt.deterministicRebuild,
+    worldContractValidated: result.receipt.worldContractValidated,
+  })}\n`);
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isMain) {
+  main().catch((error) => {
+    process.stderr.write(`${JSON.stringify(buildErrorRecord(error))}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check_process_conformance_corpus.mjs
+++ b/scripts/check_process_conformance_corpus.mjs
@@ -1,0 +1,706 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const MAX_MANIFEST_BYTES = 4 * 1024 * 1024;
+export const MAX_PAYLOAD_BYTES = 512 * 1024 * 1024;
+
+export const CORPUS_IDENTITY = Object.freeze({
+  manifestFormat: "boundary-process-v1-conformance-corpus/v1",
+  manifestAssetName: "boundary-process-v1-conformance-corpus.json",
+  payloadAssetName: "boundary-process-v1-conformance-corpus.bin",
+  producer: Object.freeze({
+    repository: "tkersey/boundary",
+    releaseTag: "v1.7.0",
+    releaseUrl: "https://github.com/tkersey/boundary/releases/tag/v1.7.0",
+    commit: "4fd4cd959ea283a6b5af12a228f0d80a102683e3",
+  }),
+  boundary: Object.freeze({
+    version: "1.7.0",
+    commit: "4fd4cd959ea283a6b5af12a228f0d80a102683e3",
+    processKernelAbiVersion: 1,
+    kernelSha256: "178f9c2fb79402a85ab5a7905586879347ad5c99f988127eec001c9ecfd813f0",
+    kernelByteLength: 647_473,
+  }),
+  receipt: Object.freeze({
+    format: "boundary-process-v1-parity-receipt/v1",
+    vectorCount: 20,
+    nativeKernelParityCount: 20,
+    needsCapacityVectorId: "needs-capacity",
+    nonAgentVectorId: "typed-effect-initial",
+  }),
+});
+
+export const REQUIRED_SCENARIOS = Object.freeze([
+  "initial-progress",
+  "ordinary-progress",
+  "typed-residual-effect",
+  "effect-morphism",
+  "recursive-call-return",
+  "explicit-yield",
+  "completion",
+  "authored-failure-v1",
+  "authored-failure-v2",
+  "pending-request-reconstruction",
+  "typed-resume",
+  "needs-capacity",
+  "non-agent",
+]);
+
+const descriptor = (id, instanceKind, effectResult, expectedKind, scenarios, operation = "execute") =>
+  Object.freeze({
+    id,
+    operation,
+    instanceKind,
+    effectResult,
+    expectedKind,
+    scenarios: Object.freeze(scenarios),
+  });
+
+export const VECTOR_DESCRIPTORS = Object.freeze([
+  descriptor("typed-effect-initial", "initialArgs", false, "Requested", ["typed-residual-effect", "non-agent"]),
+  descriptor("pending-request-reconstruction", "state", false, "Requested", ["pending-request-reconstruction"]),
+  descriptor("typed-resume", "state", true, "Completed", ["typed-resume", "completion"]),
+  descriptor("initial-progress", "initialArgs", false, "Progressed", ["initial-progress"]),
+  descriptor("explicit-yield", "initialArgs", false, "ExplicitlyYielded", ["explicit-yield"]),
+  descriptor("authored-failure-v1", "initialArgs", false, "AuthoredFailure", ["authored-failure-v1"]),
+  descriptor("authored-failure-v2-bad-math-progress", "initialArgs", false, "Progressed", ["authored-failure-v2"]),
+  descriptor("authored-failure-v2-bad-math", "state", false, "AuthoredFailure", ["authored-failure-v2"]),
+  descriptor("authored-failure-v2-bad-position-progress", "initialArgs", false, "Progressed", ["authored-failure-v2"]),
+  descriptor("authored-failure-v2-bad-position", "state", false, "AuthoredFailure", ["authored-failure-v2"]),
+  descriptor("authored-failure-v2-success", "initialArgs", false, "Completed", ["authored-failure-v2", "completion"]),
+  descriptor("effect-morphism", "initialArgs", false, "Requested", ["effect-morphism", "typed-residual-effect"]),
+  descriptor("recursion-call", "initialArgs", false, "Progressed", ["recursive-call-return", "initial-progress"]),
+  descriptor("recursion-branch", "state", false, "Progressed", ["recursive-call-return", "ordinary-progress"]),
+  descriptor("recursion-recur", "state", false, "Progressed", ["recursive-call-return", "ordinary-progress"]),
+  descriptor("recursion-base-branch", "state", false, "Progressed", ["recursive-call-return", "ordinary-progress"]),
+  descriptor("recursion-return-inner", "state", false, "Progressed", ["recursive-call-return", "ordinary-progress"]),
+  descriptor("recursion-return-root", "state", false, "Progressed", ["recursive-call-return", "ordinary-progress"]),
+  descriptor("recursion-complete", "state", false, "Completed", ["recursive-call-return", "completion"]),
+  descriptor("needs-capacity", "initialArgs", false, "NeedsCapacity", ["needs-capacity"], "prepareInput"),
+]);
+
+export const OUTCOME_KIND_BY_BYTE = Object.freeze([
+  "Progressed",
+  "Requested",
+  "ExplicitlyYielded",
+  "Completed",
+  "AuthoredFailure",
+  "NeedsCapacity",
+]);
+
+const TOP_LEVEL_KEYS = Object.freeze([
+  "format", "producer", "boundary", "payload", "artifacts", "vectors", "receipt",
+]);
+const PRODUCER_KEYS = Object.freeze(["repository", "releaseTag", "releaseUrl", "commit"]);
+const BOUNDARY_KEYS = Object.freeze([
+  "version", "commit", "processKernelAbiVersion", "kernelSha256", "kernelByteLength",
+]);
+const PAYLOAD_KEYS = Object.freeze(["assetName", "sha256", "byteLength"]);
+const ARTIFACT_KEYS = Object.freeze(["id", "offset", "byteLength", "sha256"]);
+const VECTOR_KEYS = Object.freeze([
+  "id", "scenarios", "image", "instance", "effectResult", "expectedOutcome",
+  "expectedKind", "nativeOutcomeSha256", "kernelOutcomeSha256",
+]);
+const INSTANCE_KEYS = Object.freeze(["kind", "artifact"]);
+const RECEIPT_KEYS = Object.freeze([
+  "format", "vectorCount", "nativeKernelParityCount", "needsCapacityVectorId", "nonAgentVectorId",
+]);
+const IDENTIFIER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
+
+export class CorpusValidationError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = "CorpusValidationError";
+    this.code = code;
+    this.details = Object.freeze({ ...details });
+  }
+}
+
+function fail(code, message, details = {}) {
+  throw new CorpusValidationError(code, message, details);
+}
+
+export function sha256Hex(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function exactKeys(value, expected, label) {
+  if (!isPlainObject(value)) fail("CORPUS_SCHEMA_INVALID", `${label} must be an object`, { label });
+  const observed = Object.keys(value);
+  const expectedSet = new Set(expected);
+  for (const key of expected) {
+    if (!Object.hasOwn(value, key)) {
+      fail("CORPUS_SCHEMA_INVALID", `${label} is missing ${key}`, { label, key });
+    }
+  }
+  for (const key of observed) {
+    if (!expectedSet.has(key)) {
+      fail("CORPUS_SCHEMA_INVALID", `${label} has unexpected field ${key}`, { label, key });
+    }
+  }
+  if (observed.length !== expected.length ||
+      observed.some((key, index) => key !== expected[index])) {
+    fail("CORPUS_SCHEMA_INVALID", `${label} fields are not in canonical order`, {
+      label,
+      expected,
+      observed,
+    });
+  }
+}
+
+function exactObject(value, expected, keys, label) {
+  exactKeys(value, keys, label);
+  for (const key of keys) {
+    if (value[key] !== expected[key]) {
+      fail("CORPUS_IDENTITY_MISMATCH", `${label}.${key} does not match the locked value`, {
+        label: `${label}.${key}`,
+        expected: expected[key],
+        observed: value[key],
+      });
+    }
+  }
+}
+
+function safeInteger(value, minimum, maximum, label) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    fail("CORPUS_SCHEMA_INVALID", `${label} is outside its admitted range`, {
+      label, minimum, maximum, observed: value,
+    });
+  }
+  return value;
+}
+
+function digest(value, label) {
+  if (typeof value !== "string" || !DIGEST_PATTERN.test(value)) {
+    fail("CORPUS_SCHEMA_INVALID", `${label} must be a lowercase SHA-256 digest`, { label });
+  }
+  return value;
+}
+
+function identifier(value, label) {
+  if (typeof value !== "string" || !IDENTIFIER_PATTERN.test(value)) {
+    fail("CORPUS_SCHEMA_INVALID", `${label} is not a canonical identifier`, { label, observed: value });
+  }
+  return value;
+}
+
+function exactArray(observed, expected, label) {
+  if (!Array.isArray(observed) || observed.length !== expected.length ||
+      observed.some((value, index) => value !== expected[index])) {
+    fail("CORPUS_INVENTORY_MISMATCH", `${label} does not match the locked ordered inventory`, {
+      label, expected, observed,
+    });
+  }
+}
+
+function readNatural(bytes, offset, label) {
+  let value = 0n;
+  let shift = 0n;
+  for (let index = 0; index < 10 && offset + index < bytes.length; index += 1) {
+    const byte = bytes[offset + index];
+    const payload = BigInt(byte & 0x7f);
+    if (shift === 63n && payload > 1n) break;
+    value |= payload << shift;
+    if ((byte & 0x80) === 0) {
+      const length = index + 1;
+      let canonicalLength = 1;
+      for (let remaining = value; remaining >= 0x80n; remaining >>= 7n) canonicalLength += 1;
+      if (canonicalLength !== length || value > BigInt(Number.MAX_SAFE_INTEGER)) break;
+      return Object.freeze({ value: Number(value), length });
+    }
+    shift += 7n;
+  }
+  fail("CORPUS_EFFECT_INVALID", `${label} has an invalid canonical natural`, { label });
+}
+
+function parseEffectRequest(bytes, label) {
+  if (bytes.length < 238 || !bytes.subarray(0, 8).equals(Buffer.from("ABL_ERQ1")) ||
+      bytes.readUInt16LE(8) !== 1 || bytes.readUInt16LE(10) !== 0) {
+    fail("CORPUS_EFFECT_INVALID", `${label} has a malformed ABL_ERQ1 header`, { label });
+  }
+  let cursor = 236;
+  const identityLength = readNatural(bytes, cursor, `${label} identity length`);
+  cursor += identityLength.length;
+  if (identityLength.value === 0 || identityLength.value > bytes.length - cursor) {
+    fail("CORPUS_EFFECT_INVALID", `${label} has an invalid semantic identity length`, { label });
+  }
+  let semanticIdentity;
+  try {
+    semanticIdentity = new TextDecoder("utf-8", { fatal: true }).decode(
+      bytes.subarray(cursor, cursor + identityLength.value),
+    );
+  } catch {
+    fail("CORPUS_EFFECT_INVALID", `${label} semantic identity is not valid UTF-8`, { label });
+  }
+  cursor += identityLength.value;
+  const payloadLength = readNatural(bytes, cursor, `${label} payload length`);
+  cursor += payloadLength.length;
+  if (payloadLength.value !== bytes.length - cursor) {
+    fail("CORPUS_EFFECT_INVALID", `${label} payload length does not cover the request`, { label });
+  }
+  return Object.freeze({
+    requestIdentityDigest: bytes.subarray(12, 44),
+    resumeSchemaDigest: bytes.subarray(172, 204),
+    semanticIdentity,
+    payload: bytes.subarray(cursor),
+  });
+}
+
+function parseEffectResult(bytes, label) {
+  if (bytes.length < 77 || !bytes.subarray(0, 8).equals(Buffer.from("ABL_ERS1")) ||
+      bytes.readUInt16LE(8) !== 1 || bytes.readUInt16LE(10) !== 0) {
+    fail("CORPUS_EFFECT_INVALID", `${label} has a malformed ABL_ERS1 header`, { label });
+  }
+  const resumeLength = readNatural(bytes, 76, `${label} resume length`);
+  const cursor = 76 + resumeLength.length;
+  if (resumeLength.value !== bytes.length - cursor) {
+    fail("CORPUS_EFFECT_INVALID", `${label} resume length does not cover the result`, { label });
+  }
+  return Object.freeze({
+    requestIdentityDigest: bytes.subarray(12, 44),
+    resumeSchemaDigest: bytes.subarray(44, 76),
+    resume: bytes.subarray(cursor),
+  });
+}
+
+function artifactIdsFor(descriptorValue) {
+  const ids = [
+    `${descriptorValue.id}.image`,
+    `${descriptorValue.id}.instance`,
+  ];
+  if (descriptorValue.effectResult) ids.push(`${descriptorValue.id}.effect-result`);
+  ids.push(`${descriptorValue.id}.outcome`);
+  return ids;
+}
+
+export const EXPECTED_ARTIFACT_IDS = Object.freeze(
+  VECTOR_DESCRIPTORS.flatMap(artifactIdsFor),
+);
+
+export function parseManifestBytes(bytes, label = "manifest") {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength === 0 ||
+      bytes.byteLength > MAX_MANIFEST_BYTES) {
+    fail("CORPUS_MANIFEST_INVALID", `${label} has an invalid byte length`, {
+      label, byteLength: bytes?.byteLength, maximum: MAX_MANIFEST_BYTES,
+    });
+  }
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    fail("CORPUS_MANIFEST_INVALID", `${label} is not valid UTF-8`, { label });
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(text);
+  } catch {
+    fail("CORPUS_MANIFEST_INVALID", `${label} is not valid JSON`, { label });
+  }
+  const canonical = `${JSON.stringify(manifest, null, 2)}\n`;
+  if (!Buffer.from(canonical, "utf8").equals(Buffer.from(bytes))) {
+    fail("CORPUS_MANIFEST_NONCANONICAL", `${label} is not canonical JSON`, { label });
+  }
+  return manifest;
+}
+
+export function validateCanonicalOutcome(bytes, expectedKind, label = "outcome") {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < 32) {
+    fail("CORPUS_OUTCOME_INVALID", `${label} is shorter than the ABL_PKO1 header`, { label });
+  }
+  const outcome = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (!outcome.subarray(0, 8).equals(Buffer.from("ABL_PKO1")) ||
+      outcome.readUInt16LE(8) !== 1 || outcome[10] > 5 || outcome[11] !== 0 ||
+      outcome.subarray(28, 32).some((byte) => byte !== 0)) {
+    fail("CORPUS_OUTCOME_INVALID", `${label} has a malformed ABL_PKO1 header`, { label });
+  }
+  const primaryBig = outcome.readBigUInt64LE(12);
+  const secondaryBig = outcome.readBigUInt64LE(20);
+  if (primaryBig > BigInt(Number.MAX_SAFE_INTEGER) || secondaryBig > BigInt(Number.MAX_SAFE_INTEGER)) {
+    fail("CORPUS_OUTCOME_INVALID", `${label} has unaddressable payload lengths`, { label });
+  }
+  const primary = Number(primaryBig);
+  const secondary = Number(secondaryBig);
+  if (32 + primary + secondary !== outcome.length) {
+    fail("CORPUS_OUTCOME_INVALID", `${label} payload lengths do not cover the outcome`, { label });
+  }
+  if (outcome[10] !== 1 && secondary !== 0) {
+    fail("CORPUS_OUTCOME_INVALID", `${label} has a secondary payload for a non-Requested kind`, { label });
+  }
+  if (outcome[10] === 5 && (primary !== 32 || secondary !== 0 || outcome.length !== 64)) {
+    fail("CORPUS_OUTCOME_INVALID", `${label} has a malformed NeedsCapacity payload`, { label });
+  }
+  const actualKind = OUTCOME_KIND_BY_BYTE[outcome[10]];
+  if (actualKind !== expectedKind) {
+    fail("CORPUS_OUTCOME_KIND_MISMATCH", `${label} kind does not match the vector`, {
+      label, expected: expectedKind, observed: actualKind,
+    });
+  }
+  return Object.freeze({
+    kind: actualKind,
+    primaryByteLength: primary,
+    secondaryByteLength: secondary,
+  });
+}
+
+export function validateBoundaryProcessCorpusManifest(manifest) {
+  exactKeys(manifest, TOP_LEVEL_KEYS, "manifest");
+  if (manifest.format !== CORPUS_IDENTITY.manifestFormat) {
+    fail("CORPUS_IDENTITY_MISMATCH", "manifest.format does not match the locked value");
+  }
+  exactObject(manifest.producer, CORPUS_IDENTITY.producer, PRODUCER_KEYS, "manifest.producer");
+  exactObject(manifest.boundary, CORPUS_IDENTITY.boundary, BOUNDARY_KEYS, "manifest.boundary");
+
+  exactKeys(manifest.payload, PAYLOAD_KEYS, "manifest.payload");
+  if (manifest.payload.assetName !== CORPUS_IDENTITY.payloadAssetName) {
+    fail("CORPUS_IDENTITY_MISMATCH", "manifest.payload.assetName does not match the locked value");
+  }
+  const payloadByteLength = safeInteger(
+    manifest.payload.byteLength, 1, MAX_PAYLOAD_BYTES, "manifest.payload.byteLength",
+  );
+  const payloadSha256 = digest(manifest.payload.sha256, "manifest.payload.sha256");
+
+  if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== EXPECTED_ARTIFACT_IDS.length) {
+    fail("CORPUS_INVENTORY_MISMATCH", "manifest.artifacts must contain exactly 61 records", {
+      expected: EXPECTED_ARTIFACT_IDS.length,
+      observed: manifest.artifacts?.length,
+    });
+  }
+  const artifacts = new Map();
+  let cursor = 0;
+  for (let index = 0; index < manifest.artifacts.length; index += 1) {
+    const artifact = manifest.artifacts[index];
+    const label = `manifest.artifacts[${index}]`;
+    exactKeys(artifact, ARTIFACT_KEYS, label);
+    const id = identifier(artifact.id, `${label}.id`);
+    if (id !== EXPECTED_ARTIFACT_IDS[index]) {
+      fail("CORPUS_INVENTORY_MISMATCH", `${label}.id does not match payload order`, {
+        expected: EXPECTED_ARTIFACT_IDS[index], observed: id,
+      });
+    }
+    if (artifacts.has(id)) fail("CORPUS_INVENTORY_MISMATCH", `duplicate artifact id ${id}`, { id });
+    const offset = safeInteger(artifact.offset, 0, payloadByteLength, `${label}.offset`);
+    const byteLength = safeInteger(artifact.byteLength, 0, payloadByteLength, `${label}.byteLength`);
+    if (offset !== cursor) {
+      fail("CORPUS_PARTITION_INVALID", `${label} creates a gap, overlap, or order drift`, {
+        id, expectedOffset: cursor, observedOffset: offset,
+      });
+    }
+    if (byteLength > payloadByteLength - offset) {
+      fail("CORPUS_PARTITION_INVALID", `${label} extends outside the payload`, { id, offset, byteLength });
+    }
+    const normalized = Object.freeze({
+      id,
+      offset,
+      byteLength,
+      sha256: digest(artifact.sha256, `${label}.sha256`),
+    });
+    artifacts.set(id, normalized);
+    cursor += byteLength;
+  }
+  if (cursor !== payloadByteLength) {
+    fail("CORPUS_PARTITION_INVALID", "artifact table does not cover the complete payload", {
+      coveredBytes: cursor, payloadByteLength,
+    });
+  }
+
+  if (!Array.isArray(manifest.vectors) || manifest.vectors.length !== VECTOR_DESCRIPTORS.length) {
+    fail("CORPUS_INVENTORY_MISMATCH", "manifest.vectors must contain exactly 20 vectors", {
+      expected: VECTOR_DESCRIPTORS.length, observed: manifest.vectors?.length,
+    });
+  }
+  const referencedArtifacts = [];
+  const scenarioSet = new Set();
+  const vectors = [];
+  for (let index = 0; index < VECTOR_DESCRIPTORS.length; index += 1) {
+    const expected = VECTOR_DESCRIPTORS[index];
+    const vector = manifest.vectors[index];
+    const label = `manifest.vectors[${index}]`;
+    exactKeys(vector, VECTOR_KEYS, label);
+    identifier(vector.id, `${label}.id`);
+    if (vector.id !== expected.id) {
+      fail("CORPUS_INVENTORY_MISMATCH", `${label}.id does not match the locked vector order`, {
+        expected: expected.id, observed: vector.id,
+      });
+    }
+    if (vector.scenarios.length === 0 || new Set(vector.scenarios).size !== vector.scenarios.length) {
+      fail("CORPUS_SCENARIO_INVALID", `${label}.scenarios must be nonempty and unique`, { id: vector.id });
+    }
+    for (const scenario of vector.scenarios) {
+      if (!REQUIRED_SCENARIOS.includes(scenario)) {
+        fail("CORPUS_SCENARIO_INVALID", `${label}.scenarios contains unknown scenario ${scenario}`, {
+          id: vector.id, scenario,
+        });
+      }
+      scenarioSet.add(scenario);
+    }
+    exactArray(vector.scenarios, expected.scenarios, `${label}.scenarios`);
+    const image = `${expected.id}.image`;
+    const instanceArtifact = `${expected.id}.instance`;
+    const effectResult = expected.effectResult ? `${expected.id}.effect-result` : null;
+    const expectedOutcome = `${expected.id}.outcome`;
+    if (vector.image !== image || !artifacts.has(vector.image)) {
+      fail("CORPUS_REFERENCE_INVALID", `${label}.image is not the vector-local image artifact`, { id: vector.id });
+    }
+    exactKeys(vector.instance, INSTANCE_KEYS, `${label}.instance`);
+    if (vector.instance.kind !== expected.instanceKind || vector.instance.artifact !== instanceArtifact ||
+        !artifacts.has(vector.instance.artifact)) {
+      fail("CORPUS_REFERENCE_INVALID", `${label}.instance does not match the locked vector contract`, {
+        id: vector.id,
+      });
+    }
+    if (vector.effectResult !== effectResult || (effectResult !== null && !artifacts.has(effectResult))) {
+      fail("CORPUS_REFERENCE_INVALID", `${label}.effectResult does not match the locked vector contract`, {
+        id: vector.id,
+      });
+    }
+    if (vector.expectedOutcome !== expectedOutcome || !artifacts.has(vector.expectedOutcome)) {
+      fail("CORPUS_REFERENCE_INVALID", `${label}.expectedOutcome is not the vector-local outcome`, {
+        id: vector.id,
+      });
+    }
+    if (vector.expectedKind !== expected.expectedKind) {
+      fail("CORPUS_OUTCOME_KIND_MISMATCH", `${label}.expectedKind does not match the locked vector contract`, {
+        id: vector.id, expected: expected.expectedKind, observed: vector.expectedKind,
+      });
+    }
+    const expectedDigest = artifacts.get(expectedOutcome).sha256;
+    const nativeDigest = digest(vector.nativeOutcomeSha256, `${label}.nativeOutcomeSha256`);
+    const kernelDigest = digest(vector.kernelOutcomeSha256, `${label}.kernelOutcomeSha256`);
+    if (nativeDigest !== expectedDigest || kernelDigest !== expectedDigest) {
+      fail("CORPUS_PARITY_INVALID", `${label} does not bind native, kernel, and expected bytes`, {
+        id: vector.id, expectedDigest, nativeDigest, kernelDigest,
+      });
+    }
+    referencedArtifacts.push(image, instanceArtifact);
+    if (effectResult !== null) referencedArtifacts.push(effectResult);
+    referencedArtifacts.push(expectedOutcome);
+    vectors.push(Object.freeze({ descriptor: expected, vector }));
+  }
+  if (scenarioSet.size !== REQUIRED_SCENARIOS.length ||
+      REQUIRED_SCENARIOS.some((scenario) => !scenarioSet.has(scenario))) {
+    fail("CORPUS_SCENARIO_INVALID", "manifest does not cover exactly the 13 required scenarios", {
+      expected: REQUIRED_SCENARIOS,
+      observed: [...scenarioSet],
+    });
+  }
+  exactArray(referencedArtifacts, EXPECTED_ARTIFACT_IDS, "manifest artifact references");
+
+  exactObject(manifest.receipt, CORPUS_IDENTITY.receipt, RECEIPT_KEYS, "manifest.receipt");
+  return Object.freeze({
+    manifest,
+    payload: Object.freeze({
+      assetName: CORPUS_IDENTITY.payloadAssetName,
+      byteLength: payloadByteLength,
+      sha256: payloadSha256,
+    }),
+    artifacts,
+    vectors: Object.freeze(vectors),
+  });
+}
+
+export function validateBundlePayload(validated, payloadBytes) {
+  if (!(payloadBytes instanceof Uint8Array)) {
+    fail("CORPUS_PAYLOAD_INVALID", "payload must be bytes");
+  }
+  if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES ||
+      payloadBytes.byteLength !== validated.payload.byteLength) {
+    fail("CORPUS_PAYLOAD_INVALID", "payload byte length does not match the manifest", {
+      expected: validated.payload.byteLength, observed: payloadBytes.byteLength,
+    });
+  }
+  const payload = Buffer.from(payloadBytes.buffer, payloadBytes.byteOffset, payloadBytes.byteLength);
+  const actualPayloadDigest = sha256Hex(payload);
+  if (actualPayloadDigest !== validated.payload.sha256) {
+    fail("CORPUS_PAYLOAD_INVALID", "payload digest does not match the manifest", {
+      expected: validated.payload.sha256, observed: actualPayloadDigest,
+    });
+  }
+  const files = new Map();
+  for (const [id, artifact] of validated.artifacts) {
+    const bytes = payload.subarray(artifact.offset, artifact.offset + artifact.byteLength);
+    const observed = sha256Hex(bytes);
+    if (observed !== artifact.sha256) {
+      fail("CORPUS_ARTIFACT_INVALID", `artifact ${id} digest mismatch`, {
+        id, expected: artifact.sha256, observed,
+      });
+    }
+    files.set(id, bytes);
+  }
+  for (const { descriptor: expected } of validated.vectors) {
+    validateCanonicalOutcome(
+      files.get(`${expected.id}.outcome`), expected.expectedKind, `${expected.id}.outcome`,
+    );
+  }
+  const initialRequest = files.get("typed-effect-initial.outcome");
+  const reconstructedRequest = files.get("pending-request-reconstruction.outcome");
+  const requestPrimaryLength = Number(initialRequest.readBigUInt64LE(12));
+  const requestSecondaryLength = Number(initialRequest.readBigUInt64LE(20));
+  const requestState = initialRequest.subarray(32, 32 + requestPrimaryLength);
+  const requestBytes = initialRequest.subarray(
+    32 + requestPrimaryLength,
+    32 + requestPrimaryLength + requestSecondaryLength,
+  );
+  if (!initialRequest.equals(reconstructedRequest) || requestSecondaryLength === 0 ||
+      !files.get("pending-request-reconstruction.instance").equals(requestState) ||
+      !files.get("typed-resume.instance").equals(requestState)) {
+    fail(
+      "CORPUS_VECTOR_RELATION_INVALID",
+      "pending request reconstruction and typed resume do not preserve the exact pending state/request",
+    );
+  }
+  const typedResume = files.get("typed-resume.outcome");
+  const typedResumePrimary = Number(typedResume.readBigUInt64LE(12));
+  if (typedResumePrimary !== 4 || typedResume.readUInt32LE(32) !== 29) {
+    fail("CORPUS_VECTOR_RELATION_INVALID", "typed-resume does not complete with canonical u32 value 29");
+  }
+  const typedRequest = parseEffectRequest(requestBytes, "typed-effect-initial request");
+  const typedResult = parseEffectResult(files.get("typed-resume.effect-result"), "typed-resume EffectResult");
+  if (typedRequest.semanticIdentity !== "process.kernel.fixture.lookup.v1" ||
+      typedRequest.payload.length !== 4 || typedRequest.payload.readUInt32LE(0) !== 17 ||
+      !typedResult.requestIdentityDigest.equals(typedRequest.requestIdentityDigest) ||
+      !typedResult.resumeSchemaDigest.equals(typedRequest.resumeSchemaDigest) ||
+      typedResult.resume.length !== 4 || typedResult.resume.readUInt32LE(0) !== 29) {
+    fail("CORPUS_VECTOR_RELATION_INVALID", "typed effect request/result does not bind u32 17 to matching u32 resume 29");
+  }
+  const morphismOutcome = files.get("effect-morphism.outcome");
+  const morphismPrimary = Number(morphismOutcome.readBigUInt64LE(12));
+  const morphismSecondary = Number(morphismOutcome.readBigUInt64LE(20));
+  const morphismRequest = parseEffectRequest(
+    morphismOutcome.subarray(32 + morphismPrimary, 32 + morphismPrimary + morphismSecondary),
+    "effect-morphism request",
+  );
+  if (morphismRequest.semanticIdentity !== "residual.lookup.v2" ||
+      morphismRequest.payload.length !== 4 || morphismRequest.payload.readUInt32LE(0) !== 7) {
+    fail("CORPUS_VECTOR_RELATION_INVALID", "effect-morphism does not preserve residual.lookup.v2 with u32 payload 7");
+  }
+  const primaryBytes = (id) => {
+    const outcome = files.get(`${id}.outcome`);
+    const length = Number(outcome.readBigUInt64LE(12));
+    return outcome.subarray(32, 32 + length);
+  };
+  for (const [id, expectedTag] of [
+    ["authored-failure-v1", 0],
+    ["authored-failure-v2-bad-math", 0],
+    ["authored-failure-v2-bad-position", 1],
+  ]) {
+    const failure = primaryBytes(id);
+    if (failure.length !== 4 || failure.readUInt32LE(0) !== expectedTag) {
+      fail("CORPUS_VECTOR_RELATION_INVALID", `${id} does not contain the locked authored-failure tag`);
+    }
+  }
+  const division = primaryBytes("authored-failure-v2-success");
+  if (division.length !== 1 || division[0] !== 4) {
+    fail("CORPUS_VECTOR_RELATION_INVALID", "authored-failure-v2-success does not contain quotient 4");
+  }
+  const recursionFrames = [2, 2, 3, 3, 2, 1];
+  for (let index = 0; index < recursionFrames.length; index += 1) {
+    const id = VECTOR_DESCRIPTORS[12 + index].id;
+    const state = primaryBytes(id);
+    if (state.length < 45 || !state.subarray(0, 8).equals(Buffer.from("ABL_PST1")) ||
+        state.readUInt16LE(8) !== 1 || state.readUInt16LE(10) !== 0) {
+      fail("CORPUS_VECTOR_RELATION_INVALID", `${id} does not contain canonical Process State`);
+    }
+    const frameCount = readNatural(state, 44, `${id} frame count`);
+    if (frameCount.value !== recursionFrames[index]) {
+      fail("CORPUS_VECTOR_RELATION_INVALID", `${id} has the wrong recursive frame count`, {
+        expected: recursionFrames[index],
+        observed: frameCount.value,
+      });
+    }
+  }
+  const recursionComplete = files.get("recursion-complete.outcome");
+  const recursionPrimary = Number(recursionComplete.readBigUInt64LE(12));
+  if (recursionPrimary !== 4 || recursionComplete.readUInt32LE(32) !== 1) {
+    fail("CORPUS_VECTOR_RELATION_INVALID", "recursion-complete does not return canonical u32 value 1");
+  }
+  const needsImage = files.get("needs-capacity.image");
+  const needsInstance = files.get("needs-capacity.instance");
+  const needsOutcome = files.get("needs-capacity.outcome");
+  if (needsImage.length !== 746 ||
+      sha256Hex(needsImage) !== "b62f6ea3a307fc600be79894ebd242fa07d8972e90c34194dd4219ecfc427d00" ||
+      needsInstance.length !== 33_553_647 ||
+      sha256Hex(needsInstance) !== "c039e4fb3ff6b2f59a9cc823a84e56c4db7cdf21033ce6496d04d6cbd1e9da28" ||
+      40 + needsImage.length + needsInstance.length !== 33_554_433 ||
+      needsOutcome.readBigUInt64LE(32) !== 33_554_433n ||
+      needsOutcome.readBigUInt64LE(40) !== 64n ||
+      needsOutcome.readBigUInt64LE(48) !== 0n ||
+      needsOutcome.readBigUInt64LE(56) !== 2_457n) {
+    fail("CORPUS_VECTOR_RELATION_INVALID", "needs-capacity does not bind the exact default-kernel preflight witness");
+  }
+  return files;
+}
+
+export function validateCorpusBytes(manifestBytes, payloadBytes) {
+  const manifest = parseManifestBytes(manifestBytes);
+  const validated = validateBoundaryProcessCorpusManifest(manifest);
+  const files = validateBundlePayload(validated, payloadBytes);
+  return Object.freeze({ validated, files });
+}
+
+export function canonicalJsonBytes(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export function validationErrorRecord(error) {
+  if (error instanceof CorpusValidationError) {
+    return { ok: false, code: error.code, message: error.message, details: error.details };
+  }
+  return {
+    ok: false,
+    code: "CORPUS_VALIDATION_FAILED",
+    message: error?.message ?? String(error),
+  };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  if (argv.length !== 2) {
+    throw new CorpusValidationError(
+      "CORPUS_USAGE",
+      "usage: node scripts/check_process_conformance_corpus.mjs MANIFEST PAYLOAD",
+    );
+  }
+  const readBounded = (file, maximum, label) => {
+    const stat = fs.statSync(file);
+    if (!stat.isFile() || stat.size <= 0 || stat.size > maximum) {
+      fail("CORPUS_INPUT_INVALID", `${label} must be a bounded regular file`, {
+        file, byteLength: stat.size, maximum,
+      });
+    }
+    return fs.readFileSync(file);
+  };
+  const manifestBytes = readBounded(argv[0], MAX_MANIFEST_BYTES, "manifest");
+  const payloadBytes = readBounded(argv[1], MAX_PAYLOAD_BYTES, "payload");
+  const { validated } = validateCorpusBytes(manifestBytes, payloadBytes);
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    format: "boundary-process-v1-conformance-validation/v1",
+    manifestSha256: sha256Hex(manifestBytes),
+    manifestByteLength: manifestBytes.length,
+    payloadSha256: validated.payload.sha256,
+    payloadByteLength: validated.payload.byteLength,
+    vectorCount: VECTOR_DESCRIPTORS.length,
+    artifactCount: EXPECTED_ARTIFACT_IDS.length,
+    declaredParityBindingCount: VECTOR_DESCRIPTORS.length,
+  })}\n`);
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isMain) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${JSON.stringify(validationErrorRecord(error))}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/test/process_conformance_corpus_v1.mjs
+++ b/test/process_conformance_corpus_v1.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  CORPUS_IDENTITY,
+  CorpusValidationError,
+  MAX_MANIFEST_BYTES,
+  MAX_PAYLOAD_BYTES,
+  VECTOR_DESCRIPTORS,
+  canonicalJsonBytes,
+  main as validateCorpusMain,
+  parseManifestBytes,
+  sha256Hex,
+  validateBoundaryProcessCorpusManifest,
+  validateCorpusBytes,
+} from "../scripts/check_process_conformance_corpus.mjs";
+import {
+  acquireReleasedKernel,
+  assertFileBelongsToCommit,
+  assertByteIdenticalLocalKernel,
+  assertDeterministic,
+  buildCorpusFromParityRecords,
+  CorpusBuildError,
+  generatorSourceIdentity,
+  installDirectoryAtomic,
+  parseKernelInput,
+  resolveReleaseTagCommit,
+  validateExactKernelBytes,
+  validateInstanceIdentity,
+  validateKernelModuleShape,
+  validateWorldContractModule,
+} from "../scripts/build_process_conformance_corpus.mjs";
+
+const [manifestPath, payloadPath, kernelPath] = process.argv.slice(2);
+if (manifestPath === undefined || payloadPath === undefined || process.argv.length > 5) {
+  throw new Error(
+    "usage: node test/process_conformance_corpus_v1.mjs MANIFEST PAYLOAD [EXACT_KERNEL]",
+  );
+}
+
+const manifestBytes = fs.readFileSync(manifestPath);
+const payloadBytes = fs.readFileSync(payloadPath);
+const valid = validateCorpusBytes(manifestBytes, payloadBytes);
+if (kernelPath !== undefined) validateExactKernelBytes(fs.readFileSync(kernelPath));
+
+const baseManifest = valid.validated.manifest;
+let negativeCaseCount = 0;
+
+function cloneManifest() {
+  return JSON.parse(JSON.stringify(baseManifest));
+}
+
+function expectReject(label, operation, ErrorType, expectedCodes = []) {
+  let rejected = false;
+  try {
+    operation();
+  } catch (error) {
+    if (!(error instanceof ErrorType) ||
+        (expectedCodes.length !== 0 && !expectedCodes.includes(error.code))) {
+      throw new Error(
+        `negative gate ${label} failed at the wrong boundary: ${error?.stack ?? error}`,
+      );
+    }
+    rejected = true;
+  }
+  if (!rejected) throw new Error(`negative gate accepted ${label}`);
+  negativeCaseCount += 1;
+}
+
+async function expectRejectAsync(label, operation, ErrorType, expectedCodes = []) {
+  let rejected = false;
+  try {
+    await operation();
+  } catch (error) {
+    if (!(error instanceof ErrorType) ||
+        (expectedCodes.length !== 0 && !expectedCodes.includes(error.code))) {
+      throw new Error(
+        `negative gate ${label} failed at the wrong boundary: ${error?.stack ?? error}`,
+      );
+    }
+    rejected = true;
+  }
+  if (!rejected) throw new Error(`negative gate accepted ${label}`);
+  negativeCaseCount += 1;
+}
+
+function rejectManifest(label, mutate, payload = payloadBytes) {
+  expectReject(label, () => {
+    const candidate = cloneManifest();
+    mutate(candidate);
+    validateCorpusBytes(canonicalJsonBytes(candidate), payload);
+  }, CorpusValidationError);
+}
+
+function refreshDigests(manifest, payload) {
+  manifest.payload.byteLength = payload.length;
+  manifest.payload.sha256 = sha256Hex(payload);
+  const artifacts = new Map();
+  for (const artifact of manifest.artifacts) {
+    artifact.sha256 = sha256Hex(payload.subarray(artifact.offset, artifact.offset + artifact.byteLength));
+    artifacts.set(artifact.id, artifact);
+  }
+  for (const vector of manifest.vectors) {
+    const expected = artifacts.get(vector.expectedOutcome);
+    if (expected !== undefined) {
+      vector.nativeOutcomeSha256 = expected.sha256;
+      vector.kernelOutcomeSha256 = expected.sha256;
+    }
+  }
+}
+
+function rejectPayloadMutation(label, artifactId, mutate) {
+  expectReject(label, () => {
+    const candidate = cloneManifest();
+    const payload = Buffer.from(payloadBytes);
+    const artifact = candidate.artifacts.find((value) => value.id === artifactId);
+    if (artifact === undefined) throw new Error(`missing fixture artifact ${artifactId}`);
+    mutate(payload.subarray(artifact.offset, artifact.offset + artifact.byteLength));
+    refreshDigests(candidate, payload);
+    validateCorpusBytes(canonicalJsonBytes(candidate), payload);
+  }, CorpusValidationError);
+}
+
+// Locked producer, Boundary, and kernel identity.
+for (const [label, mutation] of [
+  ["wrong producer repository", (manifest) => { manifest.producer.repository = "example/boundary"; }],
+  ["wrong release tag", (manifest) => { manifest.producer.releaseTag = "v1.7.1"; }],
+  ["wrong release URL", (manifest) => { manifest.producer.releaseUrl += "/wrong"; }],
+  ["wrong producer commit", (manifest) => { manifest.producer.commit = "0".repeat(40); }],
+  ["wrong Boundary version", (manifest) => { manifest.boundary.version = "1.7.1"; }],
+  ["wrong Boundary commit", (manifest) => { manifest.boundary.commit = "0".repeat(40); }],
+  ["wrong kernel digest", (manifest) => { manifest.boundary.kernelSha256 = "0".repeat(64); }],
+  ["wrong kernel length", (manifest) => { manifest.boundary.kernelByteLength += 1; }],
+  ["wrong kernel ABI", (manifest) => { manifest.boundary.processKernelAbiVersion = 2; }],
+]) rejectManifest(label, mutation);
+
+// Exact scenario and vector inventories.
+rejectManifest("missing required scenario", (manifest) => { manifest.vectors[0].scenarios.pop(); });
+rejectManifest("unknown scenario", (manifest) => { manifest.vectors[0].scenarios[0] = "unknown"; });
+rejectManifest("empty scenario array", (manifest) => { manifest.vectors[3].scenarios = []; });
+rejectManifest("duplicate scenario", (manifest) => {
+  manifest.vectors[0].scenarios.push(manifest.vectors[0].scenarios[0]);
+});
+rejectManifest("missing vector", (manifest) => { manifest.vectors.pop(); });
+rejectManifest("extra vector", (manifest) => { manifest.vectors.push(structuredClone(manifest.vectors[0])); });
+rejectManifest("vector order drift", (manifest) => {
+  [manifest.vectors[0], manifest.vectors[1]] = [manifest.vectors[1], manifest.vectors[0]];
+});
+rejectManifest("duplicate vector id", (manifest) => { manifest.vectors[1].id = manifest.vectors[0].id; });
+rejectManifest("invalid vector id", (manifest) => { manifest.vectors[0].id = "Not-Canonical"; });
+rejectManifest("wrong instance kind", (manifest) => { manifest.vectors[0].instance.kind = "state"; });
+rejectManifest("EffectResult on another vector", (manifest) => {
+  manifest.vectors[0].effectResult = manifest.vectors[0].instance.artifact;
+});
+rejectManifest("missing typed-resume EffectResult", (manifest) => { manifest.vectors[2].effectResult = null; });
+rejectManifest("wrong expected kind", (manifest) => { manifest.vectors[0].expectedKind = "Completed"; });
+rejectManifest("native digest divergence", (manifest) => {
+  manifest.vectors[0].nativeOutcomeSha256 = "0".repeat(64);
+});
+rejectManifest("kernel digest divergence", (manifest) => {
+  manifest.vectors[0].kernelOutcomeSha256 = "0".repeat(64);
+});
+rejectManifest("expected artifact digest divergence", (manifest) => {
+  manifest.vectors[0].nativeOutcomeSha256 = "0".repeat(64);
+  manifest.vectors[0].kernelOutcomeSha256 = "0".repeat(64);
+});
+
+// Canonical ABL_PKO1 syntax and kind binding, with all digests recomputed so
+// rejection cannot be credited to a stale hash.
+rejectPayloadMutation("malformed PKO1", "typed-effect-initial.outcome", (bytes) => { bytes[0] ^= 1; });
+rejectPayloadMutation("high-bit PKO1 magic", "typed-effect-initial.outcome", (bytes) => { bytes[0] |= 0x80; });
+rejectPayloadMutation("PKO1 kind mismatch", "recursion-complete.outcome", (bytes) => { bytes[10] = 0; });
+rejectPayloadMutation("high-bit ERQ1 magic", "typed-effect-initial.outcome", (bytes) => {
+  const primary = Number(bytes.readBigUInt64LE(12));
+  bytes[32 + primary] |= 0x80;
+});
+rejectPayloadMutation("high-bit ERS1 magic", "typed-resume.effect-result", (bytes) => { bytes[0] |= 0x80; });
+rejectPayloadMutation("authored failure tag drift", "authored-failure-v2-bad-math.outcome", (bytes) => {
+  bytes.writeUInt32LE(99, 32);
+});
+rejectPayloadMutation("authored success quotient drift", "authored-failure-v2-success.outcome", (bytes) => {
+  bytes[32] = 5;
+});
+expectReject("high-bit PKI1 magic", () => {
+  const bytes = encodeKernelInput(VECTOR_DESCRIPTORS[0], valid.files);
+  bytes[0] |= 0x80;
+  parseKernelInput(bytes);
+}, CorpusBuildError, ["NATIVE_STREAM_INVALID"]);
+
+// Exact vector-local artifact inventory and complete ordered partition.
+rejectManifest("duplicate artifact id", (manifest) => { manifest.artifacts[1].id = manifest.artifacts[0].id; });
+rejectManifest("invalid artifact id", (manifest) => { manifest.artifacts[0].id = "Invalid"; });
+rejectManifest("artifact gap", (manifest) => { manifest.artifacts[1].offset += 1; });
+rejectManifest("artifact overlap", (manifest) => { manifest.artifacts[1].offset -= 1; });
+rejectManifest("artifact outside payload", (manifest) => {
+  const artifact = manifest.artifacts.at(-1);
+  artifact.byteLength = manifest.payload.byteLength;
+});
+rejectManifest("payload not fully covered", (manifest) => { manifest.artifacts.at(-1).byteLength -= 1; });
+rejectManifest("unreferenced artifact", (manifest) => {
+  manifest.vectors[0].image = manifest.vectors[1].image;
+});
+rejectManifest("artifact digest mismatch", (manifest) => { manifest.artifacts[0].sha256 = "0".repeat(64); });
+rejectManifest("payload digest mismatch", (manifest) => { manifest.payload.sha256 = "0".repeat(64); });
+
+// Closed manifest schema and operational bounds.
+rejectManifest("manifest unexpected field", (manifest) => { manifest.unexpected = true; });
+rejectManifest("manifest missing field", (manifest) => { delete manifest.receipt; });
+expectReject("manifest field order drift", () => {
+  const entries = Object.entries(cloneManifest());
+  [entries[0], entries[1]] = [entries[1], entries[0]];
+  validateCorpusBytes(canonicalJsonBytes(Object.fromEntries(entries)), payloadBytes);
+}, CorpusValidationError, ["CORPUS_SCHEMA_INVALID"]);
+expectReject(
+  "manifest over 4 MiB",
+  () => parseManifestBytes(Buffer.from(`${JSON.stringify("x".repeat(MAX_MANIFEST_BYTES))}\n`)),
+  CorpusValidationError,
+  ["CORPUS_MANIFEST_INVALID"],
+);
+expectReject("payload over 512 MiB", () => {
+  const manifest = cloneManifest();
+  const increase = MAX_PAYLOAD_BYTES + 1 - manifest.payload.byteLength;
+  manifest.payload.byteLength = MAX_PAYLOAD_BYTES + 1;
+  manifest.artifacts.at(-1).byteLength += increase;
+  validateBoundaryProcessCorpusManifest(manifest);
+}, CorpusValidationError, ["CORPUS_SCHEMA_INVALID"]);
+expectReject("noncanonical manifest JSON", () => {
+  parseManifestBytes(Buffer.from(JSON.stringify(baseManifest), "utf8"));
+}, CorpusValidationError);
+
+// Builder-only kernel, determinism, parity, release, and World gates.
+const importedMemoryModule = new WebAssembly.Module(Buffer.from(
+  "0061736d01000000020801016d0178020001",
+  "hex",
+));
+expectReject(
+  "kernel imports",
+  () => validateKernelModuleShape(importedMemoryModule),
+  CorpusBuildError,
+  ["KERNEL_IMPORTS_PRESENT"],
+);
+expectReject(
+  "kernel runtime ABI mismatch",
+  () => validateInstanceIdentity({ boundary_process_kernel_abi_version: () => 2 }, "fixture kernel"),
+  CorpusBuildError,
+  ["KERNEL_ABI_MISMATCH"],
+);
+expectReject("local kernel differing from release", () => {
+  assertByteIdenticalLocalKernel(Buffer.from([0]), Buffer.from([1]));
+}, CorpusBuildError, ["LOCAL_KERNEL_MISMATCH"]);
+expectReject("nondeterministic rebuild", () => {
+  assertDeterministic(
+    { manifestBytes, payloadBytes, freshVectorInstanceCount: VECTOR_DESCRIPTORS.length },
+    {
+      manifestBytes: Buffer.from(manifestBytes),
+      payloadBytes: Buffer.concat([payloadBytes, Buffer.from([0])]),
+      freshVectorInstanceCount: VECTOR_DESCRIPTORS.length,
+    },
+  );
+}, CorpusBuildError, ["CORPUS_NONDETERMINISTIC"]);
+expectReject(
+  "generator commit not equal to HEAD",
+  () => generatorSourceIdentity("0".repeat(40)),
+  CorpusBuildError,
+  ["GENERATOR_IDENTITY_INVALID"],
+);
+
+const responseJson = (value) => ({
+  ok: true,
+  status: 200,
+  json: async () => value,
+  arrayBuffer: async () => Buffer.alloc(0),
+});
+await expectRejectAsync(
+  "release tag target drift",
+  () => resolveReleaseTagCommit(async () =>
+    responseJson({ object: { type: "commit", sha: "0".repeat(40) } })),
+  CorpusBuildError,
+  ["RELEASE_TAG_DRIFT"],
+);
+
+function releaseFetch(asset, downloadBytes = null) {
+  return async (url) => {
+    if (url.includes("/git/ref/tags/")) {
+      return responseJson({ object: { type: "commit", sha: CORPUS_IDENTITY.producer.commit } });
+    }
+    if (url.includes("/releases/tags/")) {
+      return responseJson({ tag_name: CORPUS_IDENTITY.producer.releaseTag, assets: [asset] });
+    }
+    if (downloadBytes !== null && url === asset.browser_download_url) {
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => downloadBytes,
+      };
+    }
+    throw new Error(`unexpected mock fetch ${url}`);
+  };
+}
+await expectRejectAsync("release asset byte-length mismatch", () => acquireReleasedKernel(releaseFetch({
+  name: "boundary-process-kernel-v1.wasm",
+  size: CORPUS_IDENTITY.boundary.kernelByteLength + 1,
+  digest: `sha256:${CORPUS_IDENTITY.boundary.kernelSha256}`,
+  browser_download_url: "https://example.invalid/kernel.wasm",
+})), CorpusBuildError, ["RELEASE_ASSET_LENGTH_MISMATCH"]);
+await expectRejectAsync("release asset digest mismatch", () => acquireReleasedKernel(releaseFetch({
+  name: "boundary-process-kernel-v1.wasm",
+  size: CORPUS_IDENTITY.boundary.kernelByteLength,
+  digest: `sha256:${"0".repeat(64)}`,
+  browser_download_url: "https://example.invalid/kernel.wasm",
+})), CorpusBuildError, ["RELEASE_ASSET_DIGEST_MISMATCH"]);
+const exactReleaseMetadata = {
+  name: "boundary-process-kernel-v1.wasm",
+  size: CORPUS_IDENTITY.boundary.kernelByteLength,
+  digest: `sha256:${CORPUS_IDENTITY.boundary.kernelSha256}`,
+  browser_download_url: "https://example.invalid/kernel.wasm",
+};
+await expectRejectAsync(
+  "downloaded release asset digest mismatch",
+  () => acquireReleasedKernel(releaseFetch(
+    exactReleaseMetadata,
+    Buffer.alloc(CORPUS_IDENTITY.boundary.kernelByteLength),
+  )),
+  CorpusBuildError,
+  ["KERNEL_IDENTITY_MISMATCH"],
+);
+expectReject("World contract rejection", () => validateWorldContractModule({
+  parseManifestBytes: () => { throw new Error("rejected"); },
+  validateBoundaryProcessCorpusManifest: () => {},
+  validateBundlePayload: () => {},
+}, manifestBytes, payloadBytes), CorpusBuildError, ["WORLD_CONTRACT_REJECTED"]);
+expectReject("World manifest rejection", () => validateWorldContractModule({
+  parseManifestBytes: () => ({}),
+  validateBoundaryProcessCorpusManifest: () => { throw new Error("rejected"); },
+  validateBundlePayload: () => {},
+}, manifestBytes, payloadBytes), CorpusBuildError, ["WORLD_CONTRACT_REJECTED"]);
+expectReject("World payload rejection", () => validateWorldContractModule({
+  parseManifestBytes: () => ({}),
+  validateBoundaryProcessCorpusManifest: () => ({}),
+  validateBundlePayload: () => { throw new Error("rejected"); },
+}, manifestBytes, payloadBytes), CorpusBuildError, ["WORLD_CONTRACT_REJECTED"]);
+
+// Reconstruct the builder's private inputs from the public partition. This
+// proves that a one-byte native mutation fails at the parity gate before any
+// manifest, payload, directory, or loose artifact is constructed.
+function encodeKernelInput(descriptor, files) {
+  const image = files.get(`${descriptor.id}.image`);
+  const instance = files.get(`${descriptor.id}.instance`);
+  const effectResult = descriptor.effectResult ? files.get(`${descriptor.id}.effect-result`) : null;
+  const bytes = Buffer.alloc(40 + image.length + instance.length + (effectResult?.length ?? 0));
+  bytes.write("ABL_PKI1", 0, "ascii");
+  bytes.writeUInt16LE(1, 8);
+  bytes[10] = descriptor.instanceKind === "initialArgs" ? 0 : 1;
+  bytes[11] = effectResult === null ? 0 : 1;
+  bytes.writeBigUInt64LE(BigInt(image.length), 12);
+  bytes.writeBigUInt64LE(BigInt(instance.length), 20);
+  bytes.writeBigUInt64LE(BigInt(effectResult?.length ?? 0), 28);
+  let cursor = 40;
+  image.copy(bytes, cursor);
+  cursor += image.length;
+  instance.copy(bytes, cursor);
+  cursor += instance.length;
+  if (effectResult !== null) effectResult.copy(bytes, cursor);
+  return bytes;
+}
+
+const parityRecords = VECTOR_DESCRIPTORS.map((descriptor) => {
+  const outcome = Buffer.from(valid.files.get(`${descriptor.id}.outcome`));
+  return Object.freeze({
+    id: descriptor.id,
+    operation: descriptor.operation,
+    input: parseKernelInput(encodeKernelInput(descriptor, valid.files), `${descriptor.id} reconstructed PKI1`),
+    nativeOutcome: outcome,
+    kernelOutcome: Buffer.from(outcome),
+  });
+});
+const reconstructed = buildCorpusFromParityRecords(parityRecords);
+if (!reconstructed.manifestBytes.equals(manifestBytes) || !reconstructed.payloadBytes.equals(payloadBytes)) {
+  throw new Error("public corpus did not reconstruct through the canonical builder");
+}
+
+const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "boundary-process-corpus-negative-"));
+try {
+  const generatedFiles = new Map([
+    [CORPUS_IDENTITY.manifestAssetName, manifestBytes],
+    [CORPUS_IDENTITY.payloadAssetName, payloadBytes],
+    ["boundary-process-v1-conformance-generation-receipt.json", Buffer.from("{}\n")],
+  ]);
+  const broadOutput = process.cwd();
+  expectReject(
+    "broad output destination",
+    () => installDirectoryAtomic(broadOutput, generatedFiles),
+    CorpusBuildError,
+    ["OUTPUT_DESTINATION_INVALID"],
+  );
+  const sentinelOutput = path.join(temporary, "unowned-output");
+  fs.mkdirSync(sentinelOutput);
+  const sentinel = path.join(sentinelOutput, "sentinel.txt");
+  fs.writeFileSync(sentinel, "preserve-me");
+  expectReject(
+    "unowned output destination",
+    () => installDirectoryAtomic(sentinelOutput, generatedFiles),
+    CorpusBuildError,
+    ["OUTPUT_DESTINATION_CONFLICT"],
+  );
+  if (fs.readFileSync(sentinel, "utf8") !== "preserve-me" ||
+      fs.readdirSync(sentinelOutput).join("\n") !== "sentinel.txt") {
+    throw new Error("unsafe output rejection changed the existing destination");
+  }
+  const oversizedPayload = path.join(temporary, "oversized-payload.bin");
+  const oversizedPayloadFile = fs.openSync(oversizedPayload, "w");
+  try {
+    fs.ftruncateSync(oversizedPayloadFile, MAX_PAYLOAD_BYTES + 1);
+  } finally {
+    fs.closeSync(oversizedPayloadFile);
+  }
+  expectReject(
+    "actual payload file over 512 MiB",
+    () => validateCorpusMain([manifestPath, oversizedPayload]),
+    CorpusValidationError,
+    ["CORPUS_INPUT_INVALID"],
+  );
+
+  const worldRoot = path.join(temporary, "world");
+  const worldScripts = path.join(worldRoot, "scripts");
+  const worldValidator = path.join(worldScripts, "acquire_process_conformance_assets.mjs");
+  fs.mkdirSync(worldScripts, { recursive: true });
+  fs.writeFileSync(worldValidator, "export const validator = true;\n");
+  const git = (argumentsList) => childProcess.execFileSync(
+    "git",
+    ["-C", worldRoot, ...argumentsList],
+    { encoding: "utf8" },
+  ).trim();
+  git(["init", "--quiet"]);
+  git(["config", "user.name", "Boundary Test"]);
+  git(["config", "user.email", "boundary-test@example.invalid"]);
+  git(["add", "scripts/acquire_process_conformance_assets.mjs"]);
+  git(["commit", "--quiet", "-m", "validator fixture"]);
+  const worldCommit = git(["rev-parse", "HEAD"]);
+  fs.appendFileSync(worldValidator, "export const dirty = true;\n");
+  expectReject(
+    "dirty World validator provenance",
+    () => assertFileBelongsToCommit(
+      worldRoot,
+      worldCommit,
+      "scripts/acquire_process_conformance_assets.mjs",
+      fs.readFileSync(worldValidator),
+    ),
+    CorpusBuildError,
+    ["WORLD_VALIDATOR_IDENTITY_INVALID"],
+  );
+
+  const mutated = parityRecords.map((record) => ({ ...record }));
+  const changedNative = Buffer.from(mutated[2].nativeOutcome);
+  changedNative[32] ^= 1;
+  mutated[2].nativeOutcome = changedNative;
+  let artifactConstructionObserved = false;
+  expectReject("native expected byte mutation before asset construction", () => {
+    buildCorpusFromParityRecords(mutated, {
+      onArtifactConstruction: () => {
+        artifactConstructionObserved = true;
+      },
+    });
+  }, CorpusBuildError, ["CORPUS_PARITY_MISMATCH"]);
+  if (artifactConstructionObserved) {
+    throw new Error("native parity mutation reached in-memory artifact construction");
+  }
+} finally {
+  fs.rmSync(temporary, { recursive: true, force: true });
+}
+
+process.stdout.write(`${JSON.stringify({
+  format: "boundary-process-v1-conformance-negative-proof/v1",
+  result: "passed",
+  negativeCaseCount,
+  vectorCount: VECTOR_DESCRIPTORS.length,
+  artifactCount: baseManifest.artifacts.length,
+  manifestSha256: sha256Hex(manifestBytes),
+  payloadSha256: sha256Hex(payloadBytes),
+})}\n`);

--- a/test/process_conformance_corpus_v1.mjs
+++ b/test/process_conformance_corpus_v1.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import {
   CORPUS_IDENTITY,
   CorpusValidationError,
+  EXPECTED_ARTIFACT_IDS,
   MAX_MANIFEST_BYTES,
   MAX_PAYLOAD_BYTES,
   VECTOR_DESCRIPTORS,
@@ -88,12 +89,12 @@ async function expectRejectAsync(label, operation, ErrorType, expectedCodes = []
   negativeCaseCount += 1;
 }
 
-function rejectManifest(label, mutate, payload = payloadBytes) {
+function rejectManifest(label, mutate, expectedCode = null, payload = payloadBytes) {
   expectReject(label, () => {
     const candidate = cloneManifest();
     mutate(candidate);
     validateCorpusBytes(canonicalJsonBytes(candidate), payload);
-  }, CorpusValidationError);
+  }, CorpusValidationError, expectedCode === null ? [] : [expectedCode]);
 }
 
 function refreshDigests(manifest, payload) {
@@ -113,7 +114,7 @@ function refreshDigests(manifest, payload) {
   }
 }
 
-function rejectPayloadMutation(label, artifactId, mutate) {
+function rejectPayloadMutation(label, artifactId, mutate, expectedCode = null) {
   expectReject(label, () => {
     const candidate = cloneManifest();
     const payload = Buffer.from(payloadBytes);
@@ -122,7 +123,7 @@ function rejectPayloadMutation(label, artifactId, mutate) {
     mutate(payload.subarray(artifact.offset, artifact.offset + artifact.byteLength));
     refreshDigests(candidate, payload);
     validateCorpusBytes(canonicalJsonBytes(candidate), payload);
-  }, CorpusValidationError);
+  }, CorpusValidationError, expectedCode === null ? [] : [expectedCode]);
 }
 
 // Locked producer, Boundary, and kernel identity.
@@ -171,14 +172,14 @@ rejectManifest("expected artifact digest divergence", (manifest) => {
 
 // Canonical ABL_PKO1 syntax and kind binding, with all digests recomputed so
 // rejection cannot be credited to a stale hash.
-rejectPayloadMutation("malformed PKO1", "typed-effect-initial.outcome", (bytes) => { bytes[0] ^= 1; });
-rejectPayloadMutation("high-bit PKO1 magic", "typed-effect-initial.outcome", (bytes) => { bytes[0] |= 0x80; });
-rejectPayloadMutation("PKO1 kind mismatch", "recursion-complete.outcome", (bytes) => { bytes[10] = 0; });
+rejectPayloadMutation("malformed PKO1", "typed-effect-initial.outcome", (bytes) => { bytes[0] ^= 1; }, "CORPUS_OUTCOME_INVALID");
+rejectPayloadMutation("high-bit PKO1 magic", "typed-effect-initial.outcome", (bytes) => { bytes[0] |= 0x80; }, "CORPUS_OUTCOME_INVALID");
+rejectPayloadMutation("PKO1 kind mismatch", "recursion-complete.outcome", (bytes) => { bytes[10] = 0; }, "CORPUS_OUTCOME_KIND_MISMATCH");
 rejectPayloadMutation("high-bit ERQ1 magic", "typed-effect-initial.outcome", (bytes) => {
   const primary = Number(bytes.readBigUInt64LE(12));
   bytes[32 + primary] |= 0x80;
 });
-rejectPayloadMutation("high-bit ERS1 magic", "typed-resume.effect-result", (bytes) => { bytes[0] |= 0x80; });
+rejectPayloadMutation("high-bit ERS1 magic", "typed-resume.effect-result", (bytes) => { bytes[0] |= 0x80; }, "CORPUS_EFFECT_INVALID");
 rejectPayloadMutation("authored failure tag drift", "authored-failure-v2-bad-math.outcome", (bytes) => {
   bytes.writeUInt32LE(99, 32);
 });
@@ -194,13 +195,15 @@ expectReject("high-bit PKI1 magic", () => {
 // Exact vector-local artifact inventory and complete ordered partition.
 rejectManifest("duplicate artifact id", (manifest) => { manifest.artifacts[1].id = manifest.artifacts[0].id; });
 rejectManifest("invalid artifact id", (manifest) => { manifest.artifacts[0].id = "Invalid"; });
-rejectManifest("artifact gap", (manifest) => { manifest.artifacts[1].offset += 1; });
-rejectManifest("artifact overlap", (manifest) => { manifest.artifacts[1].offset -= 1; });
+rejectManifest("artifact gap", (manifest) => { manifest.artifacts[1].offset += 1; }, "CORPUS_PARTITION_INVALID");
+rejectManifest("artifact overlap", (manifest) => { manifest.artifacts[1].offset -= 1; }, "CORPUS_PARTITION_INVALID");
 rejectManifest("artifact outside payload", (manifest) => {
   const artifact = manifest.artifacts.at(-1);
   artifact.byteLength = manifest.payload.byteLength;
-});
-rejectManifest("payload not fully covered", (manifest) => { manifest.artifacts.at(-1).byteLength -= 1; });
+}, "CORPUS_PARTITION_INVALID");
+rejectManifest("payload not fully covered", (manifest) => {
+  manifest.artifacts.at(-1).byteLength -= 1;
+}, "CORPUS_PARTITION_INVALID");
 rejectManifest("unreferenced artifact", (manifest) => {
   manifest.vectors[0].image = manifest.vectors[1].image;
 });
@@ -378,9 +381,53 @@ const parityRecords = VECTOR_DESCRIPTORS.map((descriptor) => {
     kernelOutcome: Buffer.from(outcome),
   });
 });
-const reconstructed = buildCorpusFromParityRecords(parityRecords);
+const constructedArtifactIds = [];
+const reconstructed = buildCorpusFromParityRecords(parityRecords, {
+  onArtifactConstruction: (id) => constructedArtifactIds.push(id),
+});
+if (constructedArtifactIds.length !== EXPECTED_ARTIFACT_IDS.length ||
+    constructedArtifactIds.some((id, index) => id !== EXPECTED_ARTIFACT_IDS[index])) {
+  throw new Error(
+    `valid reconstruction observed noncanonical artifact construction: ${JSON.stringify(constructedArtifactIds)}`,
+  );
+}
 if (!reconstructed.manifestBytes.equals(manifestBytes) || !reconstructed.payloadBytes.equals(payloadBytes)) {
   throw new Error("public corpus did not reconstruct through the canonical builder");
+}
+
+// The construction callback runs after parity verification. Mutating every
+// caller-owned buffer from that callback must not alter the verified snapshot
+// used to construct the corpus.
+const mutableAliasRecords = parityRecords.map((record) => ({
+  id: record.id,
+  operation: record.operation,
+  input: parseKernelInput(Buffer.from(record.input.bytes), `${record.id} mutable alias PKI1`),
+  nativeOutcome: Buffer.from(record.nativeOutcome),
+  kernelOutcome: Buffer.from(record.kernelOutcome),
+}));
+let mutableAliasesChanged = false;
+const ownedSnapshotReconstruction = buildCorpusFromParityRecords(mutableAliasRecords, {
+  onArtifactConstruction: () => {
+    if (mutableAliasesChanged) return;
+    mutableAliasesChanged = true;
+    for (const record of mutableAliasRecords) {
+      for (const bytes of [
+        record.input.bytes,
+        record.input.image,
+        record.input.instance,
+        record.input.effectResult,
+        record.nativeOutcome,
+        record.kernelOutcome,
+      ]) {
+        if (bytes !== null && bytes.length !== 0) bytes[0] ^= 0xff;
+      }
+    }
+  },
+});
+if (!mutableAliasesChanged ||
+    !ownedSnapshotReconstruction.manifestBytes.equals(reconstructed.manifestBytes) ||
+    !ownedSnapshotReconstruction.payloadBytes.equals(reconstructed.payloadBytes)) {
+  throw new Error("artifact construction did not use an owned verified-parity snapshot");
 }
 
 const temporary = fs.mkdtempSync(path.join(os.tmpdir(), "boundary-process-corpus-negative-"));

--- a/test/process_kernel_capacity_vector.zig
+++ b/test/process_kernel_capacity_vector.zig
@@ -14,21 +14,64 @@ const storage_capacities: process_advance_v1.StorageCapacities = .{
 };
 const Storage = process_advance_v1.CapacityStorage(storage_capacities);
 
+const default_storage_capacities: process_advance_v1.StorageCapacities = .{
+    .input = 32 * 1024 * 1024,
+    .output = 16 * 1024 * 1024,
+    .state = 8 * 1024 * 1024,
+    .value = 4 * 1024 * 1024,
+    .request = 4 * 1024 * 1024,
+    .environment = 8 * 1024 * 1024,
+    .scratch = 64 * 1024 * 1024,
+};
+const DefaultStorage = process_advance_v1.CapacityStorage(
+    default_storage_capacities,
+);
+var default_storage: DefaultStorage = .{};
+
+const expected_live_pages: u64 = 2_457;
+const expected_occupied_bytes: u64 = 160_977_264;
+const expected_input_capacity: u64 = 33_554_432;
+const required_input_length: usize = 33_554_433;
+const required_instance_length: usize = 33_553_647;
+
 pub fn main(init: std.process.Init) !void {
     var arguments = std.process.Args.Iterator.init(init.minimal.args);
     defer arguments.deinit();
     _ = arguments.skip();
-    const live_pages = try std.fmt.parseInt(
-        u64,
-        arguments.next() orelse return error.MissingLivePages,
-        10,
-    );
+    const first = arguments.next() orelse return error.MissingLivePages;
+    if (std.mem.eql(u8, first, "--conformance-corpus-v1")) {
+        const live_pages = try parseArgument(&arguments, error.MissingLivePages);
+        const occupied_bytes = try parseArgument(
+            &arguments,
+            error.MissingOccupiedBytes,
+        );
+        const input_capacity = try parseArgument(
+            &arguments,
+            error.MissingInputCapacity,
+        );
+        if (arguments.next() != null) return error.UnexpectedArgument;
+        return writeConformance(
+            init,
+            live_pages,
+            occupied_bytes,
+            input_capacity,
+        );
+    }
+    const live_pages = try std.fmt.parseInt(u64, first, 10);
     const occupied_bytes = try std.fmt.parseInt(
         u64,
         arguments.next() orelse return error.MissingOccupiedBytes,
         10,
     );
     if (arguments.next() != null) return error.UnexpectedArgument;
+    return writeLegacy(init, live_pages, occupied_bytes);
+}
+
+fn writeLegacy(
+    init: std.process.Init,
+    live_pages: u64,
+    occupied_bytes: u64,
+) !void {
     var initial: [4]u8 = undefined;
     std.mem.writeInt(u32, &initial, 17, .little);
     var storage: Storage = .{};
@@ -83,8 +126,145 @@ pub fn main(init: std.process.Init) !void {
     try stdout.flush();
 }
 
+fn writeConformance(
+    init: std.process.Init,
+    live_pages: u64,
+    occupied_bytes: u64,
+    input_capacity: u64,
+) !void {
+    if (live_pages != expected_live_pages or
+        occupied_bytes != expected_occupied_bytes or
+        input_capacity != expected_input_capacity or
+        input_capacity != @as(u64, default_storage_capacities.input) or
+        fixture.CapacityImage.bytes.len != 746)
+    {
+        return error.ReleasedKernelProbeMismatch;
+    }
+    if (@as(u64, required_input_length) != input_capacity + 1 or
+        required_instance_length + process_advance_v1.kernel_input_header_length +
+            fixture.CapacityImage.bytes.len != required_input_length)
+    {
+        return error.InvalidRequiredInputConstruction;
+    }
+
+    const initial_args = try init.gpa.alloc(u8, required_instance_length);
+    defer init.gpa.free(initial_args);
+    @memset(initial_args, 0);
+    var workspace: boundary.image.ValidationWorkspace = .{};
+    const attempt = try process_advance_v1.advanceAttemptForPhysicalStorage(
+        default_storage_capacities,
+        &fixture.CapacityImage.bytes,
+        .{ .initial_args = initial_args },
+        null,
+        &default_storage,
+        live_pages,
+        occupied_bytes,
+        &workspace,
+    );
+    try expectRequirement(attempt.outcome.needs_capacity);
+    if (attempt.capacity.requiredFor(.input) !=
+        @as(u64, required_input_length) or
+        attempt.capacity.requiredFor(.output) !=
+            process_advance_v1.needs_capacity_encoded_length or
+        attempt.capacity.requiredFor(.scratch) != 0)
+    {
+        return error.UnexpectedCapacityEvidence;
+    }
+
+    const output = try process_advance_v1.encodeOutcomeForCapacity(
+        attempt.outcome,
+        attempt.capacity,
+        required_input_length,
+        &default_storage,
+        live_pages,
+        occupied_bytes,
+        &default_storage.output.bytes,
+    );
+    try expectEncodedRequirement(output);
+    var input_header: [process_advance_v1.kernel_input_header_length]u8 =
+        undefined;
+    const header = try process_advance_v1.encodeKernelInputHeader(
+        0,
+        false,
+        @intCast(fixture.CapacityImage.bytes.len),
+        @intCast(initial_args.len),
+        0,
+        &input_header,
+    );
+
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    try stdout.writeAll("BPCGEN1\x00");
+    try writeUnsigned(stdout, u32, 1);
+    try writeUnsigned(stdout, u32, 1);
+    try writeUnsigned(stdout, u16, @intCast("needs-capacity".len));
+    try stdout.writeAll(&.{ 1, 0 });
+    try writeUnsigned(stdout, u64, @intCast(required_input_length));
+    try writeUnsigned(stdout, u64, @intCast(output.len));
+    try stdout.writeAll("needs-capacity");
+    try stdout.writeAll(header);
+    try stdout.writeAll(&fixture.CapacityImage.bytes);
+    try stdout.writeAll(initial_args);
+    try stdout.writeAll(output);
+    try stdout.flush();
+}
+
+fn expectRequirement(requirement: process_advance_v1.CapacityRequirement) !void {
+    if (requirement.minimum_input_bytes != @as(u64, required_input_length) or
+        requirement.minimum_output_bytes !=
+            process_advance_v1.needs_capacity_encoded_length or
+        requirement.minimum_scratch_bytes != 0 or
+        requirement.minimum_memory_pages != expected_live_pages)
+    {
+        return error.UnexpectedCapacityRequirement;
+    }
+}
+
+fn expectEncodedRequirement(output: []const u8) !void {
+    if (output.len != process_advance_v1.needs_capacity_encoded_length or
+        !std.mem.eql(u8, output[0..8], &process_advance_v1.outcome_magic) or
+        std.mem.readInt(u16, output[8..10], .little) !=
+            process_advance_v1.outcome_format_version or
+        output[10] != 5 or output[11] != 0 or
+        std.mem.readInt(u64, output[12..20], .little) != 32 or
+        std.mem.readInt(u64, output[20..28], .little) != 0 or
+        !allZero(output[28..32]) or
+        std.mem.readInt(u64, output[32..40], .little) !=
+            @as(u64, required_input_length) or
+        std.mem.readInt(u64, output[40..48], .little) !=
+            process_advance_v1.needs_capacity_encoded_length or
+        std.mem.readInt(u64, output[48..56], .little) != 0 or
+        std.mem.readInt(u64, output[56..64], .little) != expected_live_pages)
+    {
+        return error.UnexpectedEncodedCapacityRequirement;
+    }
+}
+
+fn allZero(bytes: []const u8) bool {
+    for (bytes) |byte| if (byte != 0) return false;
+    return true;
+}
+
+fn parseArgument(
+    arguments: *std.process.Args.Iterator,
+    missing: anyerror,
+) !u64 {
+    return std.fmt.parseInt(
+        u64,
+        arguments.next() orelse return missing,
+        10,
+    );
+}
+
 fn writeInt(writer: *std.Io.Writer, value: u32) !void {
     var bytes: [4]u8 = undefined;
     std.mem.writeInt(u32, &bytes, value, .little);
+    try writer.writeAll(&bytes);
+}
+
+fn writeUnsigned(writer: *std.Io.Writer, comptime T: type, value: T) !void {
+    var bytes: [@sizeOf(T)]u8 = undefined;
+    std.mem.writeInt(T, &bytes, value, .little);
     try writer.writeAll(&bytes);
 }

--- a/test/process_kernel_vector.zig
+++ b/test/process_kernel_vector.zig
@@ -168,11 +168,79 @@ const Storage = struct {
     }
 };
 
+const EmissionMode = enum { legacy, conformance };
+
+const Emission = struct {
+    writer: *std.Io.Writer,
+    mode: EmissionMode,
+
+    fn writeHeader(self: @This(), count: u32) !void {
+        switch (self.mode) {
+            .legacy => try writeInt(self.writer, count),
+            .conformance => {
+                try self.writer.writeAll("BPCGEN1\x00");
+                try writeUnsigned(self.writer, u32, 1);
+                try writeUnsigned(self.writer, u32, count);
+            },
+        }
+    }
+
+    fn writeVector(
+        self: @This(),
+        id: []const u8,
+        image: []const u8,
+        instance: process_advance_v1.Instance,
+        effect_result: ?[]const u8,
+        outcome: process_advance_v1.Outcome,
+    ) !void {
+        var input_storage: [128 * 1024]u8 = undefined;
+        var output_storage: [128 * 1024]u8 = undefined;
+        const input = try process_advance_v1.encodeKernelInput(
+            image,
+            instance,
+            effect_result,
+            &input_storage,
+        );
+        const output = try process_advance_v1.encodeOutcome(
+            outcome,
+            &output_storage,
+        );
+        switch (self.mode) {
+            .legacy => {
+                try writeInt(self.writer, @intCast(input.len));
+                try writeInt(self.writer, @intCast(output.len));
+            },
+            .conformance => {
+                try writeUnsigned(self.writer, u16, @intCast(id.len));
+                try self.writer.writeAll(&.{ 0, 0 });
+                try writeUnsigned(self.writer, u64, @intCast(input.len));
+                try writeUnsigned(self.writer, u64, @intCast(output.len));
+                try self.writer.writeAll(id);
+            },
+        }
+        try self.writer.writeAll(input);
+        try self.writer.writeAll(output);
+    }
+};
+
 pub fn main(init: std.process.Init) !void {
+    var arguments = std.process.Args.Iterator.init(init.minimal.args);
+    defer arguments.deinit();
+    _ = arguments.skip();
+    const mode: EmissionMode = if (arguments.next()) |argument|
+        if (std.mem.eql(u8, argument, "--conformance-corpus-v1"))
+            .conformance
+        else
+            return error.UnexpectedArgument
+    else
+        .legacy;
+    if (arguments.next() != null) return error.UnexpectedArgument;
+
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_writer = std.Io.File.stdout().writer(init.io, &stdout_buffer);
     const stdout = &stdout_writer.interface;
-    try writeInt(stdout, 15);
+    const emission: Emission = .{ .writer = stdout, .mode = mode };
+    try emission.writeHeader(if (mode == .conformance) 19 else 15);
 
     var left: Storage = .{};
     var right: Storage = .{};
@@ -186,7 +254,13 @@ pub fn main(init: std.process.Init) !void {
         left.buffers(),
         &workspace,
     );
-    try writeVector(stdout, &Image.bytes, .{ .initial_args = &initial }, null, first);
+    try emission.writeVector(
+        "typed-effect-initial",
+        &Image.bytes,
+        .{ .initial_args = &initial },
+        null,
+        first,
+    );
     const pending = first.requested;
 
     workspace = .{};
@@ -197,18 +271,26 @@ pub fn main(init: std.process.Init) !void {
         right.buffers(),
         &workspace,
     );
-    try writeVector(
-        stdout,
+    try emission.writeVector(
+        "pending-request-reconstruction",
         &Image.bytes,
         .{ .process_state = pending.state },
         null,
         second,
     );
+    try expectEquivalentRequests(first, second);
 
     const request = try boundary.process_v1.effect.validateRequest(
         pending.request,
         Image.program_transition_digest,
     );
+    if (!std.mem.eql(
+        u8,
+        request.effect_semantic_identity,
+        "process.kernel.fixture.lookup.v1",
+    ) or !std.mem.eql(u8, request.payload, &initial)) {
+        return error.UnexpectedTypedRequest;
+    }
     var resume_value: [4]u8 = undefined;
     std.mem.writeInt(u32, &resume_value, 29, .little);
     var result_storage: [256]u8 = undefined;
@@ -226,13 +308,14 @@ pub fn main(init: std.process.Init) !void {
         right.buffers(),
         &workspace,
     );
-    try writeVector(
-        stdout,
+    try emission.writeVector(
+        "typed-resume",
         &Image.bytes,
         .{ .process_state = pending.state },
         result,
         third,
     );
+    try expectU32Result(third, 29);
 
     right = .{};
     workspace = .{};
@@ -243,13 +326,14 @@ pub fn main(init: std.process.Init) !void {
         right.buffers(),
         &workspace,
     );
-    try writeVector(
-        stdout,
+    try emission.writeVector(
+        "initial-progress",
         &ProgressedImage.bytes,
         .{ .initial_args = &initial },
         null,
         fourth,
     );
+    _ = fourth.progressed;
 
     right = .{};
     workspace = .{};
@@ -260,16 +344,22 @@ pub fn main(init: std.process.Init) !void {
         right.buffers(),
         &workspace,
     );
-    try writeVector(
-        stdout,
+    try emission.writeVector(
+        "explicit-yield",
         &YieldedImage.bytes,
         .{ .initial_args = &initial },
         null,
         fifth,
     );
+    _ = fifth.explicitly_yielded;
 
     right = .{};
     workspace = .{};
+    if (FailedImage.evaluator_semantics_version !=
+        boundary.image.evaluator_semantics_v1)
+    {
+        return error.ExpectedAuthoredFailureV1Image;
+    }
     const sixth = try process_advance_v1.advance(
         &FailedImage.bytes,
         .{ .initial_args = &.{} },
@@ -277,22 +367,23 @@ pub fn main(init: std.process.Init) !void {
         right.buffers(),
         &workspace,
     );
-    try writeVector(
-        stdout,
+    try emission.writeVector(
+        "authored-failure-v1",
         &FailedImage.bytes,
         .{ .initial_args = &.{} },
         null,
         sixth,
     );
+    try expectFailureTag(sixth, 0);
 
-    try writeAuthoredFailureVectors(stdout);
-    try writeMorphismVector(stdout);
-    try writeRecursionVectors(stdout);
+    try writeAuthoredFailureVectors(emission);
+    try writeMorphismVector(emission);
+    try writeRecursionVectors(emission);
 
     try stdout.flush();
 }
 
-fn writeAuthoredFailureVectors(writer: *std.Io.Writer) !void {
+fn writeAuthoredFailureVectors(emission: Emission) !void {
     if (authored_failure.Image.evaluator_semantics_version !=
         boundary.image.evaluator_semantics_v2 or
         authored_failure.DivisionImage.evaluator_semantics_version !=
@@ -301,12 +392,16 @@ fn writeAuthoredFailureVectors(writer: *std.Io.Writer) !void {
         return error.ExpectedAuthoredFailureV2Image;
     }
     try writeAuthoredFailureCase(
-        writer,
+        emission,
+        "authored-failure-v2-bad-math-progress",
+        "authored-failure-v2-bad-math",
         &authored_failure.bad_math_initial_args,
         authored_failure.bad_math_failure_tag,
     );
     try writeAuthoredFailureCase(
-        writer,
+        emission,
+        "authored-failure-v2-bad-position-progress",
+        "authored-failure-v2-bad-position",
         &authored_failure.bad_position_initial_args,
         authored_failure.bad_position_failure_tag,
     );
@@ -314,7 +409,8 @@ fn writeAuthoredFailureVectors(writer: *std.Io.Writer) !void {
     var storage: Storage = .{};
     var workspace: boundary.image.ValidationWorkspace = .{};
     const success = try advanceAndWrite(
-        writer,
+        emission,
+        "authored-failure-v2-success",
         &authored_failure.DivisionImage.bytes,
         .{ .initial_args = &authored_failure.division_success_initial_args },
         null,
@@ -328,7 +424,9 @@ fn writeAuthoredFailureVectors(writer: *std.Io.Writer) !void {
 }
 
 fn writeAuthoredFailureCase(
-    writer: *std.Io.Writer,
+    emission: Emission,
+    started_id: []const u8,
+    failed_id: []const u8,
     initial_args: []const u8,
     expected_tag: u32,
 ) !void {
@@ -336,7 +434,8 @@ fn writeAuthoredFailureCase(
     var right: Storage = .{};
     var workspace: boundary.image.ValidationWorkspace = .{};
     const started = try advanceAndWrite(
-        writer,
+        emission,
+        started_id,
         &authored_failure.Image.bytes,
         .{ .initial_args = initial_args },
         null,
@@ -346,7 +445,8 @@ fn writeAuthoredFailureCase(
     const state = started.progressed;
     workspace = .{};
     const failed = try advanceAndWrite(
-        writer,
+        emission,
+        failed_id,
         &authored_failure.Image.bytes,
         .{ .process_state = state },
         null,
@@ -356,13 +456,14 @@ fn writeAuthoredFailureCase(
     try expectFailureTag(failed, expected_tag);
 }
 
-fn writeMorphismVector(writer: *std.Io.Writer) !void {
+fn writeMorphismVector(emission: Emission) !void {
     var initial: [4]u8 = undefined;
     std.mem.writeInt(u32, &initial, 7, .little);
     var storage: Storage = .{};
     var workspace: boundary.image.ValidationWorkspace = .{};
     const outcome = try advanceAndWrite(
-        writer,
+        emission,
+        "effect-morphism",
         &MorphismImage.bytes,
         .{ .initial_args = &initial },
         null,
@@ -382,14 +483,15 @@ fn writeMorphismVector(writer: *std.Io.Writer) !void {
     }
 }
 
-fn writeRecursionVectors(writer: *std.Io.Writer) !void {
+fn writeRecursionVectors(emission: Emission) !void {
     var initial: [4]u8 = undefined;
     std.mem.writeInt(u32, &initial, 1, .little);
     var left: Storage = .{};
     var right: Storage = .{};
     var workspace: boundary.image.ValidationWorkspace = .{};
     const called = try advanceAndWrite(
-        writer,
+        emission,
+        "recursion-call",
         &RecursionImage.bytes,
         .{ .initial_args = &initial },
         null,
@@ -401,7 +503,8 @@ fn writeRecursionVectors(writer: *std.Io.Writer) !void {
 
     workspace = .{};
     const branched = try advanceAndWrite(
-        writer,
+        emission,
+        "recursion-branch",
         &RecursionImage.bytes,
         .{ .process_state = call_state },
         null,
@@ -414,18 +517,77 @@ fn writeRecursionVectors(writer: *std.Io.Writer) !void {
     left = .{};
     workspace = .{};
     const recurred = try advanceAndWrite(
-        writer,
+        emission,
+        "recursion-recur",
         &RecursionImage.bytes,
         .{ .process_state = branch_state },
         null,
         &left,
         &workspace,
     );
-    try expectFrameCount(recurred.progressed, 3);
+    const recur_state = recurred.progressed;
+    try expectFrameCount(recur_state, 3);
+    if (emission.mode == .legacy) return;
+
+    right = .{};
+    workspace = .{};
+    const base = try advanceAndWrite(
+        emission,
+        "recursion-base-branch",
+        &RecursionImage.bytes,
+        .{ .process_state = recur_state },
+        null,
+        &right,
+        &workspace,
+    );
+    const base_state = base.progressed;
+    try expectFrameCount(base_state, 3);
+
+    left = .{};
+    workspace = .{};
+    const inner = try advanceAndWrite(
+        emission,
+        "recursion-return-inner",
+        &RecursionImage.bytes,
+        .{ .process_state = base_state },
+        null,
+        &left,
+        &workspace,
+    );
+    const inner_state = inner.progressed;
+    try expectFrameCount(inner_state, 2);
+
+    right = .{};
+    workspace = .{};
+    const root = try advanceAndWrite(
+        emission,
+        "recursion-return-root",
+        &RecursionImage.bytes,
+        .{ .process_state = inner_state },
+        null,
+        &right,
+        &workspace,
+    );
+    const root_state = root.progressed;
+    try expectFrameCount(root_state, 1);
+
+    left = .{};
+    workspace = .{};
+    const completed = try advanceAndWrite(
+        emission,
+        "recursion-complete",
+        &RecursionImage.bytes,
+        .{ .process_state = root_state },
+        null,
+        &left,
+        &workspace,
+    );
+    try expectU32Result(completed, 1);
 }
 
 fn advanceAndWrite(
-    writer: *std.Io.Writer,
+    emission: Emission,
+    id: []const u8,
     image: []const u8,
     instance: process_advance_v1.Instance,
     effect_result: ?[]const u8,
@@ -439,33 +601,46 @@ fn advanceAndWrite(
         storage.buffers(),
         workspace,
     );
-    try writeVector(writer, image, instance, effect_result, outcome);
+    try emission.writeVector(id, image, instance, effect_result, outcome);
     return outcome;
 }
 
-fn writeVector(
-    writer: *std.Io.Writer,
-    image: []const u8,
-    instance: process_advance_v1.Instance,
-    effect_result: ?[]const u8,
-    outcome: process_advance_v1.Outcome,
+fn expectEquivalentRequests(
+    left: process_advance_v1.Outcome,
+    right: process_advance_v1.Outcome,
 ) !void {
-    var input_storage: [128 * 1024]u8 = undefined;
-    var output_storage: [128 * 1024]u8 = undefined;
-    const input = try process_advance_v1.encodeKernelInput(
-        image,
-        instance,
-        effect_result,
-        &input_storage,
-    );
-    const output = try process_advance_v1.encodeOutcome(
-        outcome,
-        &output_storage,
-    );
-    try writeInt(writer, @intCast(input.len));
-    try writeInt(writer, @intCast(output.len));
-    try writer.writeAll(input);
-    try writer.writeAll(output);
+    const left_request = switch (left) {
+        .requested => |requested| requested,
+        else => return error.ExpectedRequested,
+    };
+    const right_request = switch (right) {
+        .requested => |requested| requested,
+        else => return error.ExpectedRequested,
+    };
+    if (!std.mem.eql(u8, left_request.state, right_request.state) or
+        !std.mem.eql(u8, left_request.request, right_request.request))
+    {
+        return error.PendingRequestReconstructionMismatch;
+    }
+    var left_storage: [128 * 1024]u8 = undefined;
+    var right_storage: [128 * 1024]u8 = undefined;
+    const left_bytes = try process_advance_v1.encodeOutcome(left, &left_storage);
+    const right_bytes = try process_advance_v1.encodeOutcome(right, &right_storage);
+    if (!std.mem.eql(u8, left_bytes, right_bytes)) {
+        return error.PendingOutcomeReconstructionMismatch;
+    }
+}
+
+fn expectU32Result(outcome: process_advance_v1.Outcome, expected: u32) !void {
+    const result = switch (outcome) {
+        .completed => |bytes| bytes,
+        else => return error.ExpectedCompleted,
+    };
+    if (result.len != @sizeOf(u32) or
+        std.mem.readInt(u32, result[0..@sizeOf(u32)], .little) != expected)
+    {
+        return error.UnexpectedCompletedResult;
+    }
 }
 
 fn expectFailureTag(outcome: process_advance_v1.Outcome, expected: u32) !void {
@@ -491,5 +666,11 @@ fn expectFrameCount(state: []const u8, expected: u64) !void {
 fn writeInt(writer: *std.Io.Writer, value: u32) !void {
     var bytes: [4]u8 = undefined;
     std.mem.writeInt(u32, &bytes, value, .little);
+    try writer.writeAll(&bytes);
+}
+
+fn writeUnsigned(writer: *std.Io.Writer, comptime T: type, value: T) !void {
+    var bytes: [@sizeOf(T)]u8 = undefined;
+    std.mem.writeInt(T, &bytes, value, .little);
     try writer.writeAll(&bytes);
 }


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary

Publish reusable Boundary-owned tooling and documentation for the immutable Process ABI v1 conformance corpus: exactly 20 vectors, 61 vector-local artifacts, deterministic JSON/BIN construction, native/reference-kernel byte parity, default-kernel NeedsCapacity, and independent schema validation.

## Proof

- Exact head: `093d15a4d51b10c0c51a02ec14249455570a9350`
- `zig build check ... --summary all`: 301/301 steps, 279/279 tests
- `zig build compile-fail --summary all`: 34/34 steps
- `zig build check-boundary-process-v1 --summary all`: 25/25 steps, 50/50 tests
- `zig build emit-boundary-process-kernel-v1 --summary all`: 27/27 steps, 50/50 tests
- `zig build emit-boundary-reification-assets --summary all`: 128/128 steps, 199/199 tests
- Corpus proof: 20/20 native/kernel parity, 61 artifacts, 65 focused negative gates, deterministic rebuild, pinned World contract accepted
- Kernel: 647,473 bytes, SHA-256 `178f9c2fb79402a85ab5a7905586879347ad5c99f988127eec001c9ecfd813f0`, zero imports, ABI 1
- Manifest: 24,481 bytes, SHA-256 `5ef2fb9fc3667ce97eae74d5bf9b635da46596fd7f0b3e68a04a43b24b7bb331`
- Payload: 33,578,193 bytes, SHA-256 `17a74f8adfdd7fe9aced05d01fe0432f7ad6720b69cf353bc57a695378bb527f`

## Scope

- Changes are limited to build integration, corpus tooling, native test emitters, focused tests, and documentation.
- No changes under `src/**`, `examples/**`, or `build.zig.zon`.
- Boundary runtime semantics, public APIs, wire formats, kernel ABI, kernel bytes, and release version are unchanged.

## Risks

The corpus assets are release evidence, not an ordinary runtime dependency. This PR does not attach or replace GitHub release assets and does not claim a new semantic release.

## Follow-ups

After merge, generate from the exact merged tooling commit, validate the public pair, and backfill only `boundary-process-v1-conformance-corpus.json` and `boundary-process-v1-conformance-corpus.bin` onto the existing immutable `v1.7.0` release.

## Readiness

Ready for review and exact-head landing.
<!-- ship-proof:end -->