### PR TITLE
Restore runtime image encoding and reduce compiler work

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -483,6 +483,7 @@ fn addReificationReceiptSources(
         if (source_path.len != 0) command.addFileArg(b.path(source_path));
     }
     inline for (.{
+        "build.zig.zon",
         "repo_zig_paths.txt",
         "conformance/reification-v1/baseline.lock.json",
         "conformance/reification-v1/baseline/vectors.json",
@@ -1230,6 +1231,7 @@ pub fn build(b: *std.Build) void {
         false,
     );
     reified_program_test.addImport("compiler", host_core.compiler);
+    reified_program_test.addImport("portable_value", host_core.portable_value);
     reified_program_test.addImport("image_emit_v1", host_core.image_emit_v1);
     reified_program_test.addImport("image_v1", host_core.image_v1);
     reified_program_test.addImport("kernel_v1", host_core.kernel_v1);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.8.0",
+    .version = "1.8.1",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/docs/program.md
+++ b/docs/program.md
@@ -32,6 +32,14 @@ bytecode. Its blocks define typed values, explicit edges, effects, helper calls,
 returns, and failures. Compilation validates the definition before RNF
 synthesis.
 
+`Program.image()` materializes canonical BPI1 bytes at comptime. Build tools
+can instead call `Program.encodeImage(output, workspace)` at runtime, using a
+caller-owned byte buffer and `Program.ImageEncodingWorkspace`. Both paths use
+the same encoder and produce identical bytes. Successful encoding returns the
+written prefix length; on error, discard the output prefix. The workspace may
+be reused after either success or failure and does not need initialization.
+Large tools should allocate the output and workspace outside the stack.
+
 The portable instruction set includes `enum_to_u32`, which projects an
 exhaustive enum value to its canonical unsigned tag without relying on the
 enum's backing integer type. This is the boundary-owned lowering for persisted

--- a/scripts/write_reification_receipt.mjs
+++ b/scripts/write_reification_receipt.mjs
@@ -45,6 +45,13 @@ const receiptSourceSha256 = Object.fromEntries(
 if (!isDeepStrictEqual(proofStamp.receipt_source_sha256, receiptSourceSha256)) {
   throw new Error("receipt sources are not bound to the executed proof stamp");
 }
+const manifests = receiptSourcePaths.filter((source) => path.basename(source) === "build.zig.zon");
+if (manifests.length !== 1) throw new Error("missing unique package manifest");
+const versions = [...fs.readFileSync(manifests[0], "utf8").matchAll(
+  /^\s*\.version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.+-]+)?)"\s*,/gm,
+)];
+if (versions.length !== 1) throw new Error("missing unique package version");
+const packageVersion = versions[0][1];
 const releaseAssetSha256 = {
   one_effect_image: digest(oneEffectPath),
   portable_values_image: digest(portableValuesPath),
@@ -65,8 +72,8 @@ const proofCount = (name) => {
 };
 const receipt = {
   format: "boundary-reification-receipt/v1",
-  boundary_version: "1.8.0",
-  kernel_release_version: "1.8.0",
+  boundary_version: packageVersion,
+  kernel_release_version: packageVersion,
   zig_version: "0.16.0",
   image_format: "BPI1",
   image_magic: "ABL_BPI1",

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1742,7 +1742,10 @@ fn semanticHashBytes(hasher: *SemanticHasher, value: []const u8) void {
 
 fn CachedSchemaDigest(comptime T: type) type {
     return struct {
-        const value = portable_value.schemaDigest(T);
+        const value = blk: {
+            @setEvalBranchQuota(compiler_evaluation_branch_quota);
+            break :blk portable_value.schemaDigest(T);
+        };
     };
 }
 

--- a/src/compiler.zig
+++ b/src/compiler.zig
@@ -1740,9 +1740,14 @@ fn semanticHashBytes(hasher: *SemanticHasher, value: []const u8) void {
     hasher.update(value);
 }
 
+fn CachedSchemaDigest(comptime T: type) type {
+    return struct {
+        const value = portable_value.schemaDigest(T);
+    };
+}
+
 fn semanticHashSchema(comptime T: type, hasher: *SemanticHasher) void {
-    const digest = portable_value.schemaDigest(T);
-    hasher.update(&digest);
+    hasher.update(&CachedSchemaDigest(T).value);
 }
 
 fn effectSiteContractDigest(

--- a/src/image_emit_v1.zig
+++ b/src/image_emit_v1.zig
@@ -672,28 +672,9 @@ fn RuntimeConstants(comptime Reified: type) type {
         Reified.Body.constants.len
     else
         0;
-    const scratch_bytes = comptime blk: {
-        var maximum: usize = 0;
-        for (0..Reified.semantic_canonicalization.block_count) |dense_block| {
-            const source_block = Reified.semantic_canonicalization
-                .block_dense_to_source[dense_block];
-            for (Reified.control.blocks[source_block].instructions) |instruction| {
-                const index = switch (instruction.operation) {
-                    .constant => |index| index,
-                    else => continue,
-                };
-                const value = Reified.Body.constants[index];
-                const length = portable_value.encodedSize(@TypeOf(value), value) catch |err|
-                    @compileError("invalid canonical constant: " ++ @errorName(err));
-                maximum = @max(maximum, @min(length, maximum_bytes));
-            }
-        }
-        break :blk maximum;
-    };
     return struct {
         const Self = @This();
         source_to_canonical: [source_count]?u32,
-        scratch: [scratch_bytes]u8,
 
         fn build(
             self: *Self,
@@ -703,7 +684,6 @@ fn RuntimeConstants(comptime Reified: type) type {
             @setEvalBranchQuota(100_000_000);
             self.* = .{
                 .source_to_canonical = [_]?u32{null} ** source_count,
-                .scratch = undefined,
             };
             var offsets: [Reified.compiler_limits.maximum_values]u32 = undefined;
             var lengths: [Reified.compiler_limits.maximum_values]u32 = undefined;
@@ -722,18 +702,15 @@ fn RuntimeConstants(comptime Reified: type) type {
                     };
                     const value = Reified.Body.constants[constant_index];
                     const Value = @TypeOf(value);
-                    const value_length = portable_value.encode(Value, value, &self.scratch) catch |err|
-                        switch (err) {
-                            error.CapacityExceeded => return error.SectionCapacity,
-                            else => unreachable, // The same immutable value was validated above.
-                        };
+                    const Canonical = EncodedPortableValue(Value, value);
+                    const value_length = Canonical.bytes.len;
                     const dense_value = Reified.semantic_canonicalization.valueId(
                         instruction.result,
                     );
                     const schema_id = schemas_state.root_ids[
                         RuntimeSchemas(Reified).value_root_start + dense_value
                     ];
-                    const canonical = self.scratch[0..value_length];
+                    const canonical = &Canonical.bytes;
                     var canonical_id: ?u32 = null;
                     for (0..count) |existing| {
                         if (schemas[existing] != schema_id or
@@ -770,6 +747,21 @@ fn RuntimeConstants(comptime Reified: type) type {
             }
             writer.patch(u32, count_offset, count);
         }
+    };
+}
+
+// Constants are immutable program data. Materialize their logical bytes once;
+// passing their potentially much larger carriers by value at runtime uses stack.
+fn EncodedPortableValue(comptime T: type, comptime value: T) type {
+    const length = portable_value.encodedSize(T, value) catch unreachable;
+    const encoded = comptime blk: {
+        var bytes: [length]u8 = undefined;
+        const written = portable_value.encode(T, value, &bytes) catch unreachable;
+        if (written != length) @compileError("portable value encoded length drifted");
+        break :blk bytes;
+    };
+    return struct {
+        pub const bytes = encoded;
     };
 }
 

--- a/src/image_emit_v1.zig
+++ b/src/image_emit_v1.zig
@@ -316,8 +316,23 @@ pub fn SchemaSet(comptime RootTypes: anytype) type {
 
 fn maximumSchemaNodeEncodedSize(comptime T: type) usize {
     return struct {
-        const value = uncachedMaximumSchemaNodeEncodedSize(T);
+        const value = blk: {
+            @setEvalBranchQuota(100_000_000);
+            break :blk uncachedMaximumSchemaNodeEncodedSize(T);
+        };
     }.value;
+}
+
+test "cached schema sizes retain the image encoder evaluation quota" {
+    const Fixture = struct {
+        fn Product(comptime depth: usize) type {
+            if (depth == 0) return u8;
+            const Child = Product(depth - 1);
+            return struct { left: Child, right: Child };
+        }
+    };
+    const maximum = comptime maximumSchemaNodeEncodedSize(Fixture.Product(14));
+    try std.testing.expectEqual(@as(usize, 1 << 14), maximum);
 }
 
 fn uncachedMaximumSchemaNodeEncodedSize(comptime T: type) usize {

--- a/src/image_emit_v1.zig
+++ b/src/image_emit_v1.zig
@@ -315,6 +315,12 @@ pub fn SchemaSet(comptime RootTypes: anytype) type {
 }
 
 fn maximumSchemaNodeEncodedSize(comptime T: type) usize {
+    return struct {
+        const value = uncachedMaximumSchemaNodeEncodedSize(T);
+    }.value;
+}
+
+fn uncachedMaximumSchemaNodeEncodedSize(comptime T: type) usize {
     portable_value.assertPortable(T);
     var maximum = portable_value.maximumEncodedSize(T);
     if (comptime portable_value.isVectorType(T)) {
@@ -495,8 +501,9 @@ fn RuntimeSchemas(comptime Reified: type) type {
         buckets: [schema_bucket_count]?u32,
         node_count: usize,
 
-        fn build(writer: *RuntimeWriter) RuntimeError!Self {
-            var self: Self = .{
+        fn build(self: *Self, writer: *RuntimeWriter) RuntimeError!void {
+            @setEvalBranchQuota(100_000_000);
+            self.* = .{
                 .root_ids = undefined,
                 .offsets = undefined,
                 .lengths = undefined,
@@ -510,7 +517,6 @@ fn RuntimeSchemas(comptime Reified: type) type {
                 self.root_ids[index] = try self.intern(writer, Root);
             }
             writer.patch(u32, count_offset, self.node_count);
-            return self;
         }
 
         fn intern(
@@ -518,6 +524,7 @@ fn RuntimeSchemas(comptime Reified: type) type {
             writer: *RuntimeWriter,
             comptime T: type,
         ) RuntimeError!u32 {
+            @setEvalBranchQuota(100_000_000);
             comptime portable_value.assertPortable(T);
             if (comptime portable_value.isVectorType(T)) {
                 const child = try self.intern(writer, T.ElementType);
@@ -646,6 +653,7 @@ fn RuntimeSchemas(comptime Reified: type) type {
             self: *const Self,
             comptime value_type: anytype,
         ) u32 {
+            @setEvalBranchQuota(100_000_000);
             inline for (0..value_count) |dense_value| {
                 const source_value = Reified.semantic_canonicalization
                     .value_dense_to_source[dense_value];
@@ -659,20 +667,43 @@ fn RuntimeSchemas(comptime Reified: type) type {
 }
 
 fn RuntimeConstants(comptime Reified: type) type {
+    @setEvalBranchQuota(100_000_000);
     const source_count = if (@hasDecl(Reified.Body, "constants"))
         Reified.Body.constants.len
     else
         0;
+    const scratch_bytes = comptime blk: {
+        var maximum: usize = 0;
+        for (0..Reified.semantic_canonicalization.block_count) |dense_block| {
+            const source_block = Reified.semantic_canonicalization
+                .block_dense_to_source[dense_block];
+            for (Reified.control.blocks[source_block].instructions) |instruction| {
+                const index = switch (instruction.operation) {
+                    .constant => |index| index,
+                    else => continue,
+                };
+                const value = Reified.Body.constants[index];
+                const length = portable_value.encodedSize(@TypeOf(value), value) catch |err|
+                    @compileError("invalid canonical constant: " ++ @errorName(err));
+                maximum = @max(maximum, @min(length, maximum_bytes));
+            }
+        }
+        break :blk maximum;
+    };
     return struct {
         const Self = @This();
         source_to_canonical: [source_count]?u32,
+        scratch: [scratch_bytes]u8,
 
         fn build(
+            self: *Self,
             schemas_state: *const RuntimeSchemas(Reified),
             writer: *RuntimeWriter,
-        ) RuntimeError!Self {
-            var self: Self = .{
+        ) RuntimeError!void {
+            @setEvalBranchQuota(100_000_000);
+            self.* = .{
                 .source_to_canonical = [_]?u32{null} ** source_count,
+                .scratch = undefined,
             };
             var offsets: [Reified.compiler_limits.maximum_values]u32 = undefined;
             var lengths: [Reified.compiler_limits.maximum_values]u32 = undefined;
@@ -691,15 +722,18 @@ fn RuntimeConstants(comptime Reified: type) type {
                     };
                     const value = Reified.Body.constants[constant_index];
                     const Value = @TypeOf(value);
-                    const Canonical = EncodedPortableValue(Value, value);
-                    const value_length = Canonical.bytes.len;
+                    const value_length = portable_value.encode(Value, value, &self.scratch) catch |err|
+                        switch (err) {
+                            error.CapacityExceeded => return error.SectionCapacity,
+                            else => unreachable, // The same immutable value was validated above.
+                        };
                     const dense_value = Reified.semantic_canonicalization.valueId(
                         instruction.result,
                     );
                     const schema_id = schemas_state.root_ids[
                         RuntimeSchemas(Reified).value_root_start + dense_value
                     ];
-                    const canonical = &Canonical.bytes;
+                    const canonical = self.scratch[0..value_length];
                     var canonical_id: ?u32 = null;
                     for (0..count) |existing| {
                         if (schemas[existing] != schema_id or
@@ -735,29 +769,31 @@ fn RuntimeConstants(comptime Reified: type) type {
                 }
             }
             writer.patch(u32, count_offset, count);
-            return self;
         }
     };
 }
 
-fn EncodedPortableValue(comptime T: type, comptime value: T) type {
-    const length = portable_value.encodedSize(T, value) catch unreachable;
-    const encoded = comptime blk: {
-        var bytes: [length]u8 = undefined;
-        const written = portable_value.encode(T, value, &bytes) catch unreachable;
-        if (written != length) @compileError("portable value encoded length drifted");
-        break :blk bytes;
-    };
+/// Caller-owned reusable storage initialized by each image-encoding call.
+pub fn ProgramEncodingWorkspace(comptime Reified: type) type {
     return struct {
-        pub const bytes = encoded;
+        schemas: RuntimeSchemas(Reified),
+        constants: RuntimeConstants(Reified),
     };
 }
 
-/// Encode the canonical BPI1 into caller-owned storage without materializing
-/// any complete BPI section as a comptime byte array.
+/// Encode canonical BPI1 using a local workspace and caller-owned output.
 pub fn encodeProgramImage(
     comptime Reified: type,
     output: []u8,
+) RuntimeError!usize {
+    var workspace: ProgramEncodingWorkspace(Reified) = undefined;
+    return encodeProgramImageWithWorkspace(Reified, output, &workspace);
+}
+
+pub fn encodeProgramImageWithWorkspace(
+    comptime Reified: type,
+    output: []u8,
+    workspace: *ProgramEncodingWorkspace(Reified),
 ) RuntimeError!usize {
     @setEvalBranchQuota(100_000_000);
     const maximum_single_value_bytes = comptime runtimeMaximumSingleValueBytes(Reified);
@@ -775,12 +811,13 @@ pub fn encodeProgramImage(
     lengths[0] = 28;
 
     offsets[1] = writer.cursor;
-    var schemas = try RuntimeSchemas(Reified).build(&writer);
+    try workspace.schemas.build(&writer);
+    const schemas = &workspace.schemas;
     lengths[1] = writer.cursor - offsets[1];
     if (lengths[1] > maximum_bytes) return error.SectionCapacity;
     writeProgramRootsRuntime(
         Reified,
-        &schemas,
+        schemas,
         output[@intCast(offsets[0])..][0..28],
     );
 
@@ -789,29 +826,30 @@ pub fn encodeProgramImage(
     lengths[2] = writer.cursor - offsets[2];
 
     offsets[3] = writer.cursor;
-    var constants = try RuntimeConstants(Reified).build(&schemas, &writer);
+    try workspace.constants.build(schemas, &writer);
+    const constants = &workspace.constants;
     lengths[3] = writer.cursor - offsets[3];
     if (lengths[3] > maximum_bytes) return error.SectionCapacity;
 
     offsets[4] = writer.cursor;
-    try writeProgramEffectsRuntime(Reified, &schemas, &writer);
+    try writeProgramEffectsRuntime(Reified, schemas, &writer);
     lengths[4] = writer.cursor - offsets[4];
 
     offsets[5] = writer.cursor;
-    try writeProgramValuesRuntime(Reified, &schemas, &writer);
+    try writeProgramValuesRuntime(Reified, schemas, &writer);
     lengths[5] = writer.cursor - offsets[5];
 
     offsets[6] = writer.cursor;
-    try writeProgramFunctionsRuntime(Reified, &schemas, &writer);
+    try writeProgramFunctionsRuntime(Reified, schemas, &writer);
     lengths[6] = writer.cursor - offsets[6];
 
     offsets[7] = writer.cursor;
-    try writeProgramSegmentsRuntime(Reified, &schemas, &constants, &writer);
+    try writeProgramSegmentsRuntime(Reified, schemas, constants, &writer);
     lengths[7] = writer.cursor - offsets[7];
     if (lengths[7] > maximum_bytes) return error.SectionCapacity;
 
     offsets[8] = writer.cursor;
-    try writeProgramConstructorsRuntime(Reified, &schemas, &writer);
+    try writeProgramConstructorsRuntime(Reified, schemas, &writer);
     lengths[8] = writer.cursor - offsets[8];
     if (lengths[8] > maximum_bytes) return error.SectionCapacity;
 
@@ -903,6 +941,7 @@ fn writeProgramFailuresRuntime(
     comptime Reified: type,
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     const fields = std.meta.fields(Reified.Body.Failure);
     if (!failureCatalogAdmitted(fields.len)) return error.CatalogLimit;
     try writer.append(u32, fields.len);
@@ -918,6 +957,7 @@ fn writeProgramEffectsRuntime(
     schemas: *const RuntimeSchemas(Reified),
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     const count = Reified.residual_effects.residual_count;
     try writer.append(u32, count);
     inline for (0..count) |ordinal| {
@@ -952,9 +992,10 @@ fn writeProgramValuesRuntime(
     schemas: *const RuntimeSchemas(Reified),
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     const count = Reified.semantic_canonicalization.value_count;
     try writer.append(u32, count);
-    inline for (0..count) |dense_value| {
+    for (0..count) |dense_value| {
         try writer.append(
             u32,
             schemas.root_ids[
@@ -969,6 +1010,7 @@ fn writeProgramFunctionsRuntime(
     schemas: *const RuntimeSchemas(Reified),
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     const count = Reified.semantic_canonicalization.function_count;
     try writer.append(u32, count);
     inline for (0..count) |dense_function| {
@@ -996,6 +1038,7 @@ fn writeProgramTransitionsRuntime(
     comptime Reified: type,
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     const count = Reified.rnf_value.entry_transition_count;
     const Record = struct {
         source: u16,
@@ -1004,7 +1047,7 @@ fn writeProgramTransitionsRuntime(
         constructor: u32,
     };
     var records: [count]Record = undefined;
-    inline for (0..count) |index| {
+    for (0..count) |index| {
         const transition = Reified.rnf_value.entry_transitions[index];
         records[index] = .{
             .source = Reified.semantic_canonicalization.blockId(
@@ -1084,6 +1127,7 @@ fn writeProgramConstructorsRuntime(
     schemas: *const RuntimeSchemas(Reified),
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     try writer.append(u32, Reified.rnf_value.constructor_count);
     inline for (0..Reified.rnf_value.constructor_count) |constructor_index| {
         const constructor = comptime Reified.rnf_value.constructors[constructor_index];
@@ -1172,6 +1216,7 @@ fn writeProgramSegmentsRuntime(
     constants: *const RuntimeConstants(Reified),
     writer: *RuntimeWriter,
 ) RuntimeError!void {
+    @setEvalBranchQuota(100_000_000);
     try writer.append(u32, Reified.semantic_canonicalization.block_count);
     inline for (0..Reified.semantic_canonicalization.block_count) |dense_block| {
         const source_block_id = Reified.semantic_canonicalization

--- a/src/image_emit_v1.zig
+++ b/src/image_emit_v1.zig
@@ -1165,7 +1165,7 @@ fn writeProgramConstructorsRuntime(
         try writer.append(u16, constructor.environment_len);
         try writer.append(u16, constructor.invariant_len);
         try writer.append(u16, 0);
-        inline for (0..constructor.activation_len) |field_index| {
+        for (0..constructor.activation_len) |field_index| {
             const field = constructor.activation[field_index];
             try appendEnvironmentFieldRuntime(
                 Reified,
@@ -1174,7 +1174,7 @@ fn writeProgramConstructorsRuntime(
                 writer,
             );
         }
-        inline for (0..constructor.environment_len) |field_index| {
+        for (0..constructor.environment_len) |field_index| {
             const field = constructor.environment[field_index];
             try appendEnvironmentFieldRuntime(
                 Reified,
@@ -1198,7 +1198,7 @@ fn writeProgramConstructorsRuntime(
 fn appendEnvironmentFieldRuntime(
     comptime Reified: type,
     schemas: *const RuntimeSchemas(Reified),
-    comptime field: anytype,
+    field: anytype,
     writer: *RuntimeWriter,
 ) RuntimeError!void {
     const dense_value = Reified.semantic_canonicalization.valueId(field.value);

--- a/src/program_v2.zig
+++ b/src/program_v2.zig
@@ -33,9 +33,9 @@ fn constructorFieldsEqual(
 /// Declare one typed Boundary source program with one Machine meaning.
 pub fn program(comptime label: []const u8, comptime Body: type) type {
     const Reified = compiler.ReifiedFor(label, Body);
-    const MachineV2Lowering = compiler.MachineV2LoweringFor(Reified);
-    const Definition = compiler.DirectDefinitionFor(MachineV2Lowering);
     return struct {
+        const MachineV2Lowering = compiler.MachineV2LoweringFor(Reified);
+        const Definition = compiler.DirectDefinitionFor(MachineV2Lowering);
         /// Diagnostic source label excluded from Machine semantic identity.
         pub const program_label = label;
         /// Private typed source/control program.
@@ -90,6 +90,17 @@ pub fn program(comptime label: []const u8, comptime Body: type) type {
                 pub const maximum_single_value_bytes =
                     Emitted.maximum_single_value_bytes;
             };
+        }
+
+        pub const ImageEncodingWorkspace =
+            image_emit_v1.ProgramEncodingWorkspace(Reified);
+
+        /// Encode the same canonical BPI1 into caller-owned runtime storage.
+        pub fn encodeImage(
+            output: []u8,
+            workspace: *ImageEncodingWorkspace,
+        ) image_emit_v1.RuntimeError!usize {
+            return image_emit_v1.encodeProgramImageWithWorkspace(Reified, output, workspace);
         }
 
         /// Materialize the bounded Machine ABI v2 policy separately from BPI1.

--- a/src/root.zig
+++ b/src/root.zig
@@ -10,7 +10,7 @@ const process_v1_module = @import("process_v1");
 const program_v2 = @import("program_v2");
 
 /// Published Boundary package identity.
-pub const package_version = "1.8.0";
+pub const package_version = "1.8.1";
 
 /// Public typed residual-effect authoring namespace.
 pub const effect = effect_v2;
@@ -84,7 +84,7 @@ pub const MachineOptions = machine.Options;
 test "Boundary root exposes one compiler and no legacy runtime" {
     const std = @import("std");
 
-    try std.testing.expectEqualStrings("1.8.0", package_version);
+    try std.testing.expectEqualStrings("1.8.1", package_version);
     try std.testing.expect(@hasDecl(@This(), "program"));
     try std.testing.expect(@hasDecl(@This(), "Driver"));
     try std.testing.expect(@hasDecl(@This(), "Agent"));

--- a/test/reification_receipt_v1.mjs
+++ b/test/reification_receipt_v1.mjs
@@ -99,6 +99,9 @@ try {
   fs.writeFileSync(pure, "pub const Pure = void;\n");
   const executor = path.join(temporary, "proof-executor.mjs");
   fs.writeFileSync(executor, "export const proof = true;\n");
+  const packageManifest = path.join(temporary, "build.zig.zon");
+  const manifestBytes = '.{\n    .version = "9.8.7",\n}\n';
+  fs.writeFileSync(packageManifest, manifestBytes);
   const proofPath = path.join(temporary, "boundary-reification-v1-proof.json");
   const proofArgs = [
     proofScript,
@@ -118,6 +121,7 @@ try {
     "--receipt-sources",
     pure,
     executor,
+    packageManifest,
   ];
   const proof = JSON.parse(childProcess.execFileSync(
     process.execPath,
@@ -307,13 +311,14 @@ try {
     artifact,
     pure,
     executor,
+    packageManifest,
     generated,
     proofPath,
   ];
   const receipt = JSON.parse(childProcess.execFileSync(process.execPath, args, { encoding: "utf8" }));
   if (
-    receipt.boundary_version !== "1.8.0" ||
-    receipt.kernel_release_version !== "1.8.0" ||
+    receipt.boundary_version !== "9.8.7" ||
+    receipt.kernel_release_version !== "9.8.7" ||
     receipt.image_profile_invariance_passed !== true ||
     receipt.baseline_digest_count !== 10 ||
     receipt.canonical_image_fixture_count !== 2 ||
@@ -322,6 +327,18 @@ try {
   ) {
     throw new Error("receipt did not derive claims from the executed proof stamp");
   }
+
+  fs.writeFileSync(packageManifest, manifestBytes.replace("9.8.7", "9.8.8"));
+  const staleVersionProof = childProcess.spawnSync(process.execPath, args, { encoding: "utf8" });
+  if (staleVersionProof.status === 0) throw new Error("post-proof package version change was accepted");
+  const updatedProof = childProcess.execFileSync(process.execPath, proofArgs, { encoding: "utf8" });
+  fs.writeFileSync(proofPath, updatedProof);
+  const updatedReceipt = JSON.parse(childProcess.execFileSync(process.execPath, args, { encoding: "utf8" }));
+  if (updatedReceipt.boundary_version !== "9.8.8" || updatedReceipt.kernel_release_version !== "9.8.8") {
+    throw new Error("receipt did not follow the proved package version");
+  }
+  fs.writeFileSync(packageManifest, manifestBytes);
+  fs.writeFileSync(proofPath, JSON.stringify(proof));
 
   const replacementKernel = path.join(temporary, "replacement-kernel.bin");
   fs.writeFileSync(replacementKernel, "replacement");

--- a/test/reified_program_v1.zig
+++ b/test/reified_program_v1.zig
@@ -5,6 +5,7 @@ const image_v1 = @import("image_v1");
 const kernel_v1 = @import("kernel_v1");
 const machine = @import("machine");
 const machine_v2_profile_v1 = @import("machine_v2_profile_v1");
+const portable_value = @import("portable_value");
 const program_v2 = @import("program_v2");
 const reducer_clause_v1 = @import("reducer_clause_v1");
 const std = @import("std");
@@ -388,6 +389,79 @@ test "Program runtime encoder is byte-identical to Program.image" {
     );
     const repeated_length = try Program.encodeImage(&output, &workspace);
     try std.testing.expectEqualSlices(u8, &Image.bytes, output[0..repeated_length]);
+}
+
+fn ConstantEncodingFixture(comptime Value: type, comptime value: Value) type {
+    const ConstantBody = struct {
+        pub const InitialArgs = void;
+        pub const Result = Value;
+        pub const Failure = enum { rejected };
+        pub const effect_sites = .{};
+        pub const schema_types = .{Value};
+        pub const constants = .{value};
+        pub const control_ir: cir.Program = .{
+            .label = "large-constant-encoding",
+            .value_types = &.{.{ .schema = 0 }},
+            .blocks = &.{.{
+                .id = 0,
+                .instructions = &.{.{
+                    .kind = .constant,
+                    .operation = .{ .constant = 0 },
+                    .result = 0,
+                }},
+                .terminator = .{ .return_value = 0 },
+            }},
+            .entry = 0,
+            .result_type = .{ .schema = 0 },
+        };
+    };
+    const ConstantProgram = program_v2.program("large-constant-encoding", ConstantBody);
+    return struct {
+        const Expected = ConstantProgram.image();
+        var output: [Expected.bytes.len]u8 = undefined;
+        var workspace: ConstantProgram.ImageEncodingWorkspace = undefined;
+
+        fn expectParity() !void {
+            const length = try ConstantProgram.encodeImage(&output, &workspace);
+            try std.testing.expectEqualSlices(u8, &Expected.bytes, output[0..length]);
+        }
+    };
+}
+
+test "runtime image encoding does not stack-copy large constant carriers" {
+    const Bytes = portable_value.Bytes(16 << 20);
+    try ConstantEncodingFixture(Bytes, Bytes.empty()).expectParity();
+    try ConstantEncodingFixture(?[10 * 1024 * 1024]u8, null).expectParity();
+}
+
+fn NestedProduct(comptime depth: usize) type {
+    if (depth == 0) return u8;
+    const Child = NestedProduct(depth - 1);
+    return struct { left: Child, right: Child };
+}
+
+test "cached schema digests retain the compiler evaluation quota" {
+    const Value = NestedProduct(11);
+    const NestedBody = struct {
+        pub const InitialArgs = Value;
+        pub const Result = Value;
+        pub const Failure = enum { rejected };
+        pub const effect_sites = .{};
+        pub const schema_types = .{Value};
+        pub const control_ir: cir.Program = .{
+            .label = "nested-product-identity",
+            .value_types = &.{.{ .schema = 0 }},
+            .blocks = &.{.{
+                .id = 0,
+                .parameters = &.{0},
+                .terminator = .{ .return_value = 0 },
+            }},
+            .entry = 0,
+            .result_type = .{ .schema = 0 },
+        };
+    };
+    const Nested = program_v2.program("nested-product-identity", NestedBody);
+    try std.testing.expectEqual(@as(usize, 32), Nested.program_transition_digest.len);
 }
 
 test "non-unit root result rejects valueless completion" {

--- a/test/reified_program_v1.zig
+++ b/test/reified_program_v1.zig
@@ -375,6 +375,21 @@ test "canonical encoder fills an exact buffer with duplicate schema roots" {
     try std.testing.expectEqualSlices(u8, &Image.bytes, output[0..length]);
 }
 
+test "Program runtime encoder is byte-identical to Program.image" {
+    var output: [Image.bytes.len]u8 = undefined;
+    var workspace: Program.ImageEncodingWorkspace = undefined;
+    const length = try Program.encodeImage(&output, &workspace);
+    try std.testing.expectEqual(Image.bytes.len, length);
+    try std.testing.expectEqualSlices(u8, &Image.bytes, output[0..length]);
+    try std.testing.expectError(error.OutputCapacity, Program.encodeImage(output[0..0], &workspace));
+    try std.testing.expectError(
+        error.OutputCapacity,
+        Program.encodeImage(output[0 .. output.len - 1], &workspace),
+    );
+    const repeated_length = try Program.encodeImage(&output, &workspace);
+    try std.testing.expectEqualSlices(u8, &Image.bytes, output[0..repeated_length]);
+}
+
 test "non-unit root result rejects valueless completion" {
     var malformed = Image.bytes;
     const envelope = try image_v1.validateEnvelope(&malformed);

--- a/test/single_reducer.zig
+++ b/test/single_reducer.zig
@@ -95,12 +95,14 @@ comptime {
     if (!@hasDecl(Program, "compile") or
         !@hasDecl(Program, "compileV2") or
         !@hasDecl(Program, "image") or
+        !@hasDecl(Program, "encodeImage") or
+        !@hasDecl(Program, "ImageEncodingWorkspace") or
         !@hasDecl(Program, "machineV2Profile") or
         !@hasDecl(Program, "kernelMachineV2") or
         @hasDecl(Program, "kernelMachine") or
-        functionDeclarationCount(Program) != 5)
+        functionDeclarationCount(Program) != 6)
     {
-        @compileError("Boundary Program exposes a competing compilation route");
+        @compileError("Boundary Program public operation inventory drifted");
     }
     for (.{
         "component",


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary

- Restore `Program.encodeImage(output, workspace)` and caller-owned `ImageEncodingWorkspace` through the canonical encoder, preserving `Program.image()` bytes and Machine ABI v2.
- Cache schema computations with their existing compiler/encoder evaluation allowances, defer unused Machine-v2 lowering, and avoid specializing ordinary runtime constructor fields.
- Keep immutable constants as canonical byte data, avoiding runtime copies of large-capacity carriers.
- Derive receipt versions from the proof-bound package manifest and track that manifest as a build input.
- Prepare 1.8.1 to correct the public runtime-encoder omission discovered downstream. The published 1.8.0 tag and assets remain untouched.

## Review corrections

- Empty 16 MiB `Bytes` and null optional 10 MiB arrays now encode using caller-owned output/workspace without carrier-sized stack copies; runtime/comptime bytes match.
- Both schema-digest and image-size caches retain their original evaluation allowances. Regression tests cover nested products; the larger complete image case also compiles successfully.
- Receipt tests exercise two different manifest versions and require a fresh proof after a version change. Generated receipts now report 1.8.1.

## Proof

- Exact head: `fc012cf84f67933ef70cbea295e9ab5966fdce3c`.
- `zig build check emit-boundary-process-kernel-v1 emit-boundary-reification-assets -j4 --summary all`: **321/321 steps, 295/295 tests**; includes compile-fail, image, reification, lint, release and kernel proof targets.
- Four added Zig regression tests explain the increase from the base's 291 tests to 295.
- `node test/reification_receipt_v1.mjs`: pass, including manifest-version transition and stale-proof rejection.
- Zig 0.16.0. Formatting and diff checks pass.
- Production Process kernel remains **682,943 bytes**, SHA-256 `4da38268f12e8a2749a266480748da5460b5030dadfc10804f79ba3a3bb8013e`, zero imports, ABI 1; 21 native/WASM outcomes match byte-for-byte.
- Full downstream cold image command on this head: **99.59 seconds**, fresh local/global caches, runtime safety enabled. All four outputs match the baseline: BPI1, source map, InitialArgs, and expected final Result.
- Downstream BPI1 remains 95,508 bytes, SHA-256 `51cc746c20cda6aa3f643a4d916a70f7066c0270c5fcda6fc0e582080852210d`.

## Scope

- Repository: `tkersey/boundary`
- Branch: `fix/runtime-image-encoding-v1`
- Head: `fc012cf84f67933ef70cbea295e9ab5966fdce3c`
- Base: `main` at `9772a22838c3243c746379e292de01230cb60eda`
- No kernel, ABI, image-format, State-format, or application-policy change.

## Risks

Failed encoding may modify an output prefix; discard failed output. This is documented, and workspace reuse after failure is tested.

## Follow-ups

Restart exact-head serial review, then merge and publish the successor from its landed tree before rebinding downstream releases.

## Readiness

- Operation: update
- Final state: preserve
- SHIP-v1 compatibility mode: update-existing
- Reason: the review corrections and regression tests pass; this successor is ready for fresh review.
- Caveats: not yet merged or released; no live-model claim.
<!-- ship-proof:end -->
