### PR TITLE
Enforce source image budgets at canonical emission

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -2722,6 +2722,10 @@ pub fn build(b: *std.Build) void {
             "BPI1 schema members exceed validator capacity",
         },
         .{
+            "test/compile_fail/image_source_byte_limit.zig",
+            "Boundary Program image exceeds maximum_image_bytes",
+        },
+        .{
             "test/compile_fail/oversized_machine_state.zig",
             "Boundary Machine maximum_state_bytes must fit canonical u32 and one canonical frame",
         },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .boundary,
-    .version = "1.8.1",
+    .version = "1.8.2",
     .dependencies = .{
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter?ref=0.16.x#9b4d67b9725e7137ac876cc628fe5dd2ca5a2681",

--- a/docs/program.md
+++ b/docs/program.md
@@ -21,6 +21,7 @@ const Machine = Program.compile(.{
 - a tuple of structured `schema_types`;
 - optional canonical constants in a heterogeneous tuple or homogeneous array;
 - optional bounded `compiler_limits`;
+- optional `maximum_image_bytes`, a physical image-emission capacity;
 - one typed `control_ir`.
 
 The source label is diagnostic. Executable semantics, portable schemas, RNF
@@ -39,6 +40,13 @@ the same encoder and produce identical bytes. Successful encoding returns the
 written prefix length; on error, discard the output prefix. The workspace may
 be reused after either success or failure and does not need initialization.
 Large tools should allocate the output and workspace outside the stack.
+
+When `Body.maximum_image_bytes` is declared, both emission paths enforce it.
+`image()` reports a compile error for an oversized image; `encodeImage()` returns
+`error.OutputCapacity` even when the caller supplies a larger buffer, and never
+writes beyond the declared capacity. The limit is checked when emitting an image,
+not when declaring the Program type. It does not alter successful image bytes,
+transition identity, or direct Machine ABI v2 specialization.
 
 The portable instruction set includes `enum_to_u32`, which projects an
 exhaustive enum value to its canonical unsigned tag without relying on the

--- a/repo_zig_paths.txt
+++ b/repo_zig_paths.txt
@@ -49,6 +49,7 @@ test/compile_fail/image_effect_catalog_limit.zig
 test/compile_fail/image_failure_variant_limit.zig
 test/compile_fail/image_function_catalog_limit.zig
 test/compile_fail/image_schema_member_limit.zig
+test/compile_fail/image_source_byte_limit.zig
 test/compile_fail/machine_state_below_entry_environment.zig
 test/compile_fail/missing_arithmetic_failure.zig
 test/compile_fail/non_enum_failure_tagged_union.zig

--- a/src/program_v2.zig
+++ b/src/program_v2.zig
@@ -33,6 +33,10 @@ fn constructorFieldsEqual(
 /// Declare one typed Boundary source program with one Machine meaning.
 pub fn program(comptime label: []const u8, comptime Body: type) type {
     const Reified = compiler.ReifiedFor(label, Body);
+    const image_byte_limit: ?usize = if (@hasDecl(Body, "maximum_image_bytes"))
+        Body.maximum_image_bytes
+    else
+        null;
     return struct {
         const MachineV2Lowering = compiler.MachineV2LoweringFor(Reified);
         const Definition = compiler.DirectDefinitionFor(MachineV2Lowering);
@@ -76,6 +80,11 @@ pub fn program(comptime label: []const u8, comptime Body: type) type {
         /// Emit the profile-independent canonical Boundary Program Image.
         pub fn image() type {
             const Emitted = image_emit_v1.ProgramImage(Reified);
+            if (image_byte_limit) |limit| {
+                if (Emitted.byte_length > limit) {
+                    @compileError("Boundary Program image exceeds maximum_image_bytes");
+                }
+            }
             return struct {
                 pub const format_version = Emitted.format_version;
                 pub const evaluator_semantics_version =
@@ -100,7 +109,15 @@ pub fn program(comptime label: []const u8, comptime Body: type) type {
             output: []u8,
             workspace: *ImageEncodingWorkspace,
         ) image_emit_v1.RuntimeError!usize {
-            return image_emit_v1.encodeProgramImageWithWorkspace(Reified, output, workspace);
+            const bounded_output = if (image_byte_limit) |limit|
+                output[0..@min(output.len, limit)]
+            else
+                output;
+            return image_emit_v1.encodeProgramImageWithWorkspace(
+                Reified,
+                bounded_output,
+                workspace,
+            );
         }
 
         /// Materialize the bounded Machine ABI v2 policy separately from BPI1.

--- a/src/root.zig
+++ b/src/root.zig
@@ -10,7 +10,7 @@ const process_v1_module = @import("process_v1");
 const program_v2 = @import("program_v2");
 
 /// Published Boundary package identity.
-pub const package_version = "1.8.1";
+pub const package_version = "1.8.2";
 
 /// Public typed residual-effect authoring namespace.
 pub const effect = effect_v2;
@@ -84,7 +84,7 @@ pub const MachineOptions = machine.Options;
 test "Boundary root exposes one compiler and no legacy runtime" {
     const std = @import("std");
 
-    try std.testing.expectEqualStrings("1.8.1", package_version);
+    try std.testing.expectEqualStrings("1.8.2", package_version);
     try std.testing.expect(@hasDecl(@This(), "program"));
     try std.testing.expect(@hasDecl(@This(), "Driver"));
     try std.testing.expect(@hasDecl(@This(), "Agent"));

--- a/test/compile_fail/image_source_byte_limit.zig
+++ b/test/compile_fail/image_source_byte_limit.zig
@@ -1,0 +1,26 @@
+const cir = @import("control_ir");
+const program_v2 = @import("program_v2");
+
+const Body = struct {
+    pub const InitialArgs = u32;
+    pub const Result = u32;
+    pub const Failure = enum { rejected };
+    pub const effect_sites = .{};
+    pub const schema_types = .{};
+    pub const maximum_image_bytes = 1;
+    pub const control_ir: cir.Program = .{
+        .label = "image-source-byte-limit",
+        .value_types = &.{.{ .scalar = .u32 }},
+        .blocks = &.{.{
+            .id = 0,
+            .parameters = &.{0},
+            .terminator = .{ .return_value = 0 },
+        }},
+        .entry = 0,
+        .result_type = .{ .scalar = .u32 },
+    };
+};
+
+comptime {
+    _ = program_v2.program("image-source-byte-limit", Body).image();
+}

--- a/test/program_compile.zig
+++ b/test/program_compile.zig
@@ -58,6 +58,44 @@ const Body = struct {
 };
 
 const Program = program_v2.program("typed-lookup", Body);
+
+fn ImageBoundBody(comptime capacity: usize) type {
+    return struct {
+        pub const InitialArgs = Body.InitialArgs;
+        pub const Result = Body.Result;
+        pub const Failure = Body.Failure;
+        pub const contract_bytes = Body.contract_bytes;
+        pub const effect_sites = Body.effect_sites;
+        pub const schema_types = Body.schema_types;
+        pub const control_ir = Body.control_ir;
+        pub const maximum_image_bytes = capacity;
+    };
+}
+
+test "image byte admission belongs to both canonical emission paths" {
+    const expected = Program.image().bytes;
+    inline for (.{ 0, 1, expected.len - 1, expected.len, expected.len + 16 }) |limit| {
+        const Limited = program_v2.program("typed-lookup", ImageBoundBody(limit));
+        const workspace = try std.testing.allocator.create(Limited.ImageEncodingWorkspace);
+        defer std.testing.allocator.destroy(workspace);
+        var output: [expected.len + 32]u8 = @splat(0xaa);
+        if (comptime limit < expected.len) {
+            try std.testing.expectError(error.OutputCapacity, Limited.encodeImage(&output, workspace));
+            for (output[limit..]) |byte| try std.testing.expectEqual(@as(u8, 0xaa), byte);
+        } else {
+            try std.testing.expectEqualSlices(u8, &expected, &Limited.image().bytes);
+            try std.testing.expectError(
+                error.OutputCapacity,
+                Limited.encodeImage(output[0 .. expected.len - 1], workspace),
+            );
+            const length = try Limited.encodeImage(&output, workspace);
+            try std.testing.expectEqual(expected.len, length);
+            try std.testing.expectEqualSlices(u8, &expected, output[0..length]);
+            for (output[length..]) |byte| try std.testing.expectEqual(@as(u8, 0xaa), byte);
+        }
+    }
+}
+
 const CompiledMachine = Program.compile(.{
     .maximum_frames = 4,
     .maximum_state_bytes = 4096,


### PR DESCRIPTION
<!-- ship-proof:start -->
## Summary

- Enforce optional `Body.maximum_image_bytes` at both canonical image-emission paths: compile-time `Program.image()` and caller-owned runtime `Program.encodeImage()`.
- A larger caller buffer cannot bypass the source budget. Exact-fit output remains canonical, failed output remains discardable, and the workspace remains reusable.
- Keep Program declaration separate from image materialization, preserve direct Machine ABI v2 specialization, and prepare the corrective v1.8.2 release without changing earlier tags or assets.

## Proof

- Fresh exact-head `zig build check compile-fail check-boundary-image check-boundary-reified-core emit-boundary-process-kernel-v1 emit-boundary-reification-assets -j4 --summary all`: **322/322 steps, 296/296 tests passed**.
- Independent clean-checkout `zig build emit-boundary-process-kernel-v1 emit-boundary-reification-assets -j4 --summary all`: **158/158 steps, 249/249 tests passed**; all **13 release assets byte-identical** to the first build.
- Generic capacity witnesses cover zero, one byte, one byte below the actual image size, exact fit, larger capacity, oversized caller buffers, and workspace reuse after failed encoding. The compile-time over-budget witness rejects as required.
- Process kernel remains **682,943 bytes**, SHA-256 `4da38268f12e8a2749a266480748da5460b5030dadfc10804f79ba3a3bb8013e`, **zero imports**, **ABI v1**, with **21/21 native/WASM outcomes identical**.
- Downstream qualification against this exact Boundary head: the current unpublished Agent working tree passed its fresh aggregate, **126/126 steps and 16/16 tests**, in **118.94 seconds**. Its canonical image remains **95,508 bytes**, SHA-256 `51cc746c20cda6aa3f643a4d916a70f7066c0270c5fcda6fc0e582080852210d`. This is consumer qualification, not Agent release or review closure.

## Scope

- Repository: `tkersey/boundary`
- Branch: `fix/image-emission-byte-limit`
- Head: `37adc6a26bf22749f90fb4f7fda4860c78dd0029`
- Base: `main`
- Base SHA: `09d3dbe2004d20e9e29f7c3d4b635cd32857b101`

## Risks

The new optional field constrains image emission only. Bodies without it retain existing behavior. No BPI1, Process State, evaluator, kernel, Agent-policy, or provider semantics changed. Required exact-head review is pending; this PR is not merge-authorized by a clean build alone.

## Follow-ups

Complete the required exact-head review, squash merge, rebuild and verify the public patch release, then rebind World and Agent in order. No implementation is deferred within this patch.

## Readiness

- Operation: create
- Final state: ready
- SHIP-v1 compatibility mode: ready
- Reason: implementation and exact-head validation are complete; required review follows publication.
- Caveats: downstream qualification uses the unpublished Agent working tree; final downstream releases still require their own rebind, proofs, reviews, and public readback.
<!-- ship-proof:end -->
