### PR TITLE
Strengthen Lean trust, effectful identity, and trace guarantees

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   formal-core:
     runs-on: ubuntu-24.04
@@ -35,14 +39,24 @@ jobs:
           echo "$RUNNER_TEMP/lean/bin" >> "$GITHUB_PATH"
       - name: Export the offline validation workspace
         if: github.head_ref == 'codex/lean-proof-boundary-hardening'
-        run: git archive --format=tar.gz --output="$RUNNER_TEMP/boundary-source.tar.gz" HEAD
+        run: |
+          git archive --format=tar.gz --output="$RUNNER_TEMP/boundary-source.tar.gz" HEAD
+          split -b 300M "$RUNNER_TEMP/lean.tar.zst" "$RUNNER_TEMP/lean-part-"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: github.head_ref == 'codex/lean-proof-boundary-hardening'
         with:
-          name: linux-proof-workspace
+          name: linux-proof-workspace-a
           path: |
-            ${{ runner.temp }}/lean.tar.zst
+            ${{ runner.temp }}/lean-part-aa
             ${{ runner.temp }}/boundary-source.tar.gz
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: github.head_ref == 'codex/lean-proof-boundary-hardening'
+        with:
+          name: linux-proof-workspace-b
+          path: ${{ runner.temp }}/lean-part-ab
           compression-level: 0
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,0 +1,40 @@
+name: Lean formal core
+
+on:
+  pull_request:
+    paths:
+      - 'semantics/v2/**'
+      - '.github/workflows/lean.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'semantics/v2/**'
+      - '.github/workflows/lean.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  formal-core:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install the pinned Lean distribution
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(cat semantics/v2/lean-toolchain)" = 'leanprover/lean4:v4.33.1'
+          curl --fail --location --retry 3 --output "$RUNNER_TEMP/lean.tar.zst" \
+            https://github.com/leanprover/lean4/releases/download/v4.33.1/lean-4.33.1-linux.tar.zst
+          echo "890afd185370f85666025b883914ab4f4b339136f8c96167b69cfb62aecaf235  $RUNNER_TEMP/lean.tar.zst" | sha256sum --check
+          mkdir "$RUNNER_TEMP/lean"
+          tar --zstd -xf "$RUNNER_TEMP/lean.tar.zst" --strip-components=1 -C "$RUNNER_TEMP/lean"
+          echo "$RUNNER_TEMP/lean/bin" >> "$GITHUB_PATH"
+      - name: Check the formal core and trust boundary
+        working-directory: semantics/v2
+        run: |
+          lake build
+          lake env lean Trust.lean

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -33,6 +33,19 @@ jobs:
           mkdir "$RUNNER_TEMP/lean"
           tar --zstd -xf "$RUNNER_TEMP/lean.tar.zst" --strip-components=1 -C "$RUNNER_TEMP/lean"
           echo "$RUNNER_TEMP/lean/bin" >> "$GITHUB_PATH"
+      - name: Export the offline validation workspace
+        if: github.head_ref == 'codex/lean-proof-boundary-hardening'
+        run: git archive --format=tar.gz --output="$RUNNER_TEMP/boundary-source.tar.gz" HEAD
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: github.head_ref == 'codex/lean-proof-boundary-hardening'
+        with:
+          name: linux-proof-workspace
+          path: |
+            ${{ runner.temp }}/lean.tar.zst
+            ${{ runner.temp }}/boundary-source.tar.gz
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
       - name: Check the formal core and trust boundary
         working-directory: semantics/v2
         run: |

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'semantics/v2/**'
+      - 'build.zig'
       - '.github/workflows/lean.yml'
   push:
     branches: [main]
     paths:
       - 'semantics/v2/**'
+      - 'build.zig'
       - '.github/workflows/lean.yml'
 
 permissions:
@@ -21,11 +23,15 @@ concurrency:
 jobs:
   formal-core:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '26.8.1'
+          package-manager-cache: false
       - name: Install the pinned Lean distribution
         shell: bash
         run: |
@@ -37,31 +43,17 @@ jobs:
           mkdir "$RUNNER_TEMP/lean"
           tar --zstd -xf "$RUNNER_TEMP/lean.tar.zst" --strip-components=1 -C "$RUNNER_TEMP/lean"
           echo "$RUNNER_TEMP/lean/bin" >> "$GITHUB_PATH"
-      - name: Export the offline validation workspace
-        if: github.head_ref == 'codex/lean-proof-boundary-hardening'
+      - name: Install Zig 0.16.0
+        shell: bash
         run: |
-          git archive --format=tar.gz --output="$RUNNER_TEMP/boundary-source.tar.gz" HEAD
-          split -b 300M "$RUNNER_TEMP/lean.tar.zst" "$RUNNER_TEMP/lean-part-"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: github.head_ref == 'codex/lean-proof-boundary-hardening'
-        with:
-          name: linux-proof-workspace-a
-          path: |
-            ${{ runner.temp }}/lean-part-aa
-            ${{ runner.temp }}/boundary-source.tar.gz
-          compression-level: 0
-          retention-days: 1
-          if-no-files-found: error
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: github.head_ref == 'codex/lean-proof-boundary-hardening'
-        with:
-          name: linux-proof-workspace-b
-          path: ${{ runner.temp }}/lean-part-ab
-          compression-level: 0
-          retention-days: 1
-          if-no-files-found: error
-      - name: Check the formal core and trust boundary
-        working-directory: semantics/v2
-        run: |
-          lake build
-          lake env lean Trust.lean
+          set -euo pipefail
+          curl --fail --location --retry 3 --output "$RUNNER_TEMP/zig.tar.xz" \
+            https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz
+          echo "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00  $RUNNER_TEMP/zig.tar.xz" | sha256sum --check
+          mkdir "$RUNNER_TEMP/zig"
+          tar -xf "$RUNNER_TEMP/zig.tar.xz" --strip-components=1 -C "$RUNNER_TEMP/zig"
+          echo "$RUNNER_TEMP/zig" >> "$GITHUB_PATH"
+      - name: Check the formal core and trust-policy mutations
+        run: node semantics/v2/check.mjs --self-test
+      - name: Check repository integration
+        run: zig build check-v2 -Doptimize=ReleaseSafe -j2 --summary all

--- a/build.zig
+++ b/build.zig
@@ -133,14 +133,10 @@ pub fn build(b: *std.Build) void {
     semantics.dependOn(&oracleScopeChecks(b, boundary, optimize).step);
     semantics.dependOn(&borrowReturnChecks(b, boundary, optimize).step);
     semantics.dependOn(&b.addRunArtifact(authoring).step);
-    const formal = b.addSystemCommand(&.{ "lake", "build" });
-    formal.setCwd(b.path("semantics/v2"));
+    const formal = b.addSystemCommand(&.{"node"});
+    formal.addFileArg(b.path("semantics/v2/check.mjs"));
     formal.has_side_effects = true;
-    const trust = b.addSystemCommand(&.{ "lake", "env", "lean", "Trust.lean" });
-    trust.setCwd(b.path("semantics/v2"));
-    trust.has_side_effects = true;
-    trust.step.dependOn(&formal.step);
-    semantics.dependOn(&trust.step);
+    semantics.dependOn(&formal.step);
     const aggregate = b.step("check-v2", "Check compiler, source semantics, formal core, data and economy without a runtime");
     aggregate.dependOn(data_step);
     aggregate.dependOn(historical_step);

--- a/semantics/v2/BoundaryV2.lean
+++ b/semantics/v2/BoundaryV2.lean
@@ -3,3 +3,4 @@ import BoundaryV2.Lowering
 import BoundaryV2.ControlLowering
 import BoundaryV2.Regions
 import BoundaryV2.EffectsExamples
+import BoundaryV2.EffectsChecks

--- a/semantics/v2/BoundaryV2/Effects.lean
+++ b/semantics/v2/BoundaryV2/Effects.lean
@@ -342,9 +342,16 @@ def Machine.Valid (machine : Machine A outside result) : Prop :=
   | .pending pending => machine.ownership.live = [pending.token]
   | _ => machine.ownership.live = []
 
+/-- Reserve above every ambient identity. The requested supply is a lower bound;
+an already sufficient supply is unchanged. Empty environments allocate nothing. -/
+def reserveAttachments : List Nat → Nat → Nat
+  | [], fresh => fresh
+  | identity :: rest, fresh => max (identity + 1) (reserveAttachments rest fresh)
+
 def initial (body : Flow A 0 caps [] result) (capabilities : Capabilities caps)
     (fresh : Nat) : Machine A 0 result :=
-  ⟨.empty, fresh, .running ⟨0, result, .code body .nil capabilities, .nil, .done⟩⟩
+  ⟨.empty, reserveAttachments capabilities.toList fresh,
+    .running ⟨0, result, .code body .nil capabilities, .nil, .done⟩⟩
 
 theorem initial_is_well_owned (body : Flow A 0 caps [] result)
     (capabilities : Capabilities caps) (fresh : Nat) : (initial body capabilities fresh).Valid :=

--- a/semantics/v2/BoundaryV2/EffectsChecks.lean
+++ b/semantics/v2/BoundaryV2/EffectsChecks.lean
@@ -1,0 +1,77 @@
+import BoundaryV2.EffectsExamples
+import BoundaryV2.EffectsTrace
+
+namespace BoundaryV2.Effects.Checks
+
+open Core Control Examples
+
+set_option maxRecDepth 10000
+
+/-- Slot 1 denotes the ambient capability, not the newly entered handler. The
+requested supply deliberately collides with that ambient identity. -/
+def ambientUnderHandler : Flow Expr 0 1 [] .number :=
+  .handle ⟨.ref .here, .dispose (constant 99)⟩ (.perform 1 (constant 41))
+
+def ambientStart : Machine Expr 0 .number := initial ambientUnderHandler #[0].toVector 0
+
+theorem ambient_identity_is_reserved : ambientStart.freshAttachment = 1 := rfl
+
+theorem ambient_operation_remains_residual :
+    observe (ticks Expr.eval 2 ambientStart) = some (.request 0 41) := rfl
+
+theorem compiled_ambient_operation_remains_residual :
+    observe (ticks evaluateBlock 2 (compileMachine ambientStart)) = some (.request 0 41) := rfl
+
+/-- Two distinct requests have identical identities and payloads. Extra internal
+polls occur while pending and after completion. Only polling is silent. -/
+def identicalRequests : Flow Expr 0 1 [] .number :=
+  .bind (.perform 0 (constant 41)) (.perform 0 (constant 41))
+
+def identicalStart : Machine Expr 0 .number := initial identicalRequests #[7].toVector 8
+
+def polledInputs : List Input := [.internal, .internal, .internal, .resume 10,
+  .internal, .internal, .internal, .resume 20, .internal, .internal, .internal]
+
+theorem distinct_equal_requests_are_not_deduplicated :
+    (driveEvents Expr.eval identicalStart polledInputs).map Prod.snd =
+      some [.request 7 41, .request 7 41, .returned (.number 20)] := rfl
+
+theorem compiled_event_trace_matches :
+    (driveEvents evaluateBlock (compileMachine identicalStart) polledInputs).map Prod.snd =
+      some [.request 7 41, .request 7 41, .returned (.number 20)] := rfl
+
+theorem sampling_api_is_unchanged :
+    (drive Expr.eval identicalStart [.internal, .internal, .internal]).map Prod.snd =
+      some [.request 7 41, .request 7 41] := rfl
+
+theorem disposal_is_emitted_once :
+    (driveEvents Expr.eval identicalStart [.internal, .internal, .dispose, .internal, .internal]).map Prod.snd =
+      some [.request 7 41, .disposed] := rfl
+
+theorem transfer_is_emitted_once :
+    (driveEvents Expr.eval identicalStart [.internal, .internal, .transfer, .internal, .internal]).map Prod.snd =
+      some [.request 7 41, .transferred 7 41] := rfl
+
+theorem repeated_disposition_still_rejects :
+    driveEvents Expr.eval identicalStart [.internal, .internal, .dispose, .dispose] = none := rfl
+
+/-- The dormant inner template contains both a captured capability alias and
+an outside capability. Activation must rename the former and retain the latter. -/
+def aliasTemplate (identity : Nat) : Stack Expr 0 .number 0 .number :=
+  .push (.delimiter identity ⟨.ref .here, .dispose (constant 0)⟩ .nil)
+    (.push (.repeat
+      (.push (.bind (.perform 0 (constant 0)) .nil #[identity, 7].toVector) .done)
+      .done [1] (.number 0) (.ref .here) .nil) .done)
+
+theorem dormant_aliases_are_renamed_together :
+    (aliasTemplate 3).activate 10 = (aliasTemplate 10, 11) := by
+  simp [aliasTemplate, Stack.activate, Stack.attachments, Stack.rename, Frame.rename, renameLocal]
+
+theorem next_activation_uses_a_disjoint_interval :
+    (aliasTemplate 3).activate 11 = (aliasTemplate 11, 12) := by
+  simp [aliasTemplate, Stack.activate, Stack.attachments, Stack.rename, Frame.rename, renameLocal]
+
+theorem dormant_aliases_are_bounded : (aliasTemplate 3).Below 10 := by
+  simp [aliasTemplate, Stack.Below, Frame.Below, NamesBelow]
+
+end BoundaryV2.Effects.Checks

--- a/semantics/v2/BoundaryV2/EffectsIdentity.lean
+++ b/semantics/v2/BoundaryV2/EffectsIdentity.lean
@@ -1,0 +1,344 @@
+import BoundaryV2.Effects
+
+namespace BoundaryV2.Effects
+
+open Core Control
+
+/-- Reconstruct both sides of the delimiter selected in the *effectful* stack. -/
+def Selected.whole (selected : Selected A r a s b) : Stack A r a s b :=
+  selected.inside.append
+    (.push (.delimiter selected.identity selected.handler selected.env) selected.outsideStack)
+
+theorem selection_reconstructs_stack (stack : Stack A r a s b) (identity : Nat)
+    (selected : Selected A r a s b) (found : select identity stack = some selected) :
+    selected.whole = stack := by
+  induction stack using Stack.spine_induction with
+  | done => simp [select] at found
+  | push frame rest ih =>
+    cases frame with
+    | delimiter actual handler env =>
+      simp only [select] at found
+      split at found
+      · cases found; rfl
+      · simp only [Option.map_eq_some_iff] at found
+        obtain ⟨inner, found, rfl⟩ := found
+        exact congrArg (Stack.push (.delimiter actual handler env)) (ih inner found)
+    | bind | region | post | «repeat» =>
+      simp only [select, Option.map_eq_some_iff] at found
+      obtain ⟨inner, found, rfl⟩ := found
+      exact congrArg (Stack.push _) (ih inner found)
+
+theorem selection_uses_identity (stack : Stack A r a s b) (identity : Nat)
+    (selected : Selected A r a s b) (found : select identity stack = some selected) :
+    selected.identity = identity := by
+  induction stack using Stack.spine_induction with
+  | done => simp [select] at found
+  | push frame rest ih =>
+    cases frame with
+    | delimiter actual handler env =>
+      simp only [select] at found
+      split at found
+      next same => cases found; exact same.symm
+      next =>
+        simp only [Option.map_eq_some_iff] at found
+        obtain ⟨inner, found, rfl⟩ := found
+        exact ih inner found
+    | bind | region | post | «repeat» =>
+      simp only [select, Option.map_eq_some_iff] at found
+      obtain ⟨inner, found, rfl⟩ := found
+      exact ih inner found
+
+theorem selection_is_nearest (stack : Stack A r a s b) (identity : Nat)
+    (selected : Selected A r a s b) (found : select identity stack = some selected) :
+    identity ∉ selected.inside.attachments := by
+  induction stack using Stack.spine_induction with
+  | done => simp [select] at found
+  | push frame rest ih =>
+    cases frame with
+    | delimiter actual handler env =>
+      simp only [select] at found
+      split at found
+      · cases found; simp [Stack.attachments]
+      next different =>
+        simp only [Option.map_eq_some_iff] at found
+        obtain ⟨inner, found, rfl⟩ := found
+        simpa [Selected.prepend, Stack.attachments, different] using ih inner found
+    | bind | region | post | «repeat» =>
+      simp only [select, Option.map_eq_some_iff] at found
+      obtain ⟨inner, found, rfl⟩ := found
+      exact ih inner found
+
+theorem selection_absent_iff (stack : Stack A r a s b) (identity : Nat) :
+    select identity stack = none ↔ identity ∉ stack.attachments := by
+  induction stack using Stack.spine_induction with
+  | done => simp [select, Stack.attachments]
+  | push frame rest ih =>
+    cases frame with
+    | delimiter actual handler env =>
+      by_cases same : identity = actual
+      · simp [select, Stack.attachments, same]
+      · simp [select, Stack.attachments, same, ih]
+    | bind | region | post | «repeat» => simpa [select, Stack.attachments] using ih
+
+/-- Bounds cover capability aliases as well as delimiter identities, recursively
+including dormant templates. Heap numbers and ordinary values are not names. -/
+def NamesBelow (fresh : Nat) (names : List Nat) : Prop := ∀ id ∈ names, id < fresh
+
+mutual
+  def Frame.Below (fresh : Nat) : Frame A r a s b → Prop
+    | .bind _ _ caps => NamesBelow fresh caps.toList
+    | .delimiter identity _ _ => identity < fresh
+    | .region | .post _ _ => True
+    | .repeat template _ _ _ _ _ => template.Below fresh
+
+  def Stack.Below (fresh : Nat) : Stack A r a s b → Prop
+    | .done => True
+    | .push frame rest => frame.Below fresh ∧ rest.Below fresh
+end
+
+theorem reserve_attachments_lower_bound (names : List Nat) (fresh : Nat) :
+    fresh ≤ reserveAttachments names fresh := by
+  induction names with
+  | nil => exact Nat.le_refl fresh
+  | cons id rest ih => exact Nat.le_trans ih (Nat.le_max_right _ _)
+
+theorem reserve_attachments_above (names : List Nat) (fresh : Nat) :
+    NamesBelow (reserveAttachments names fresh) names := by
+  induction names with
+  | nil => simp [NamesBelow]
+  | cons id rest ih =>
+    intro name member
+    rcases List.mem_cons.mp member with rfl | member
+    · simp only [reserveAttachments]; omega
+    · have := ih name member
+      simp only [reserveAttachments]; omega
+
+theorem reserve_attachments_unchanged (names : List Nat) (fresh : Nat)
+    (bound : NamesBelow fresh names) : reserveAttachments names fresh = fresh := by
+  induction names with
+  | nil => rfl
+  | cons id rest ih =>
+    have head := bound id (by simp)
+    have tail : NamesBelow fresh rest := fun n h => bound n (List.mem_cons_of_mem id h)
+    simp only [reserveAttachments, ih tail]
+    omega
+
+theorem rename_local_shared (ids : List Nat) (fresh identity : Nat)
+    (shared : identity ∉ ids) : renameLocal ids fresh identity = identity := by
+  simp [renameLocal, shared]
+
+theorem rename_local_fresh (ids : List Nat) (fresh identity : Nat)
+    (captured : identity ∈ ids) :
+    fresh ≤ renameLocal ids fresh identity ∧ renameLocal ids fresh identity < fresh + ids.length := by
+  have := List.idxOf_lt_length_of_mem captured
+  simp only [renameLocal, if_pos captured]
+  omega
+
+theorem rename_local_bounded (ids : List Nat) (fresh identity : Nat) (old : identity < fresh) :
+    renameLocal ids fresh identity < fresh + ids.length := by
+  by_cases captured : identity ∈ ids
+  · exact (rename_local_fresh ids fresh identity captured).2
+  · rw [rename_local_shared ids fresh identity captured]; omega
+
+/-- Finite substitution need not be injective on all Nat. It is injective on the
+reachable old names below the reserved supply, which is the required domain. -/
+theorem rename_local_injective_below (ids : List Nat) (fresh a b : Nat)
+    (ha : a < fresh) (hb : b < fresh)
+    (same : renameLocal ids fresh a = renameLocal ids fresh b) : a = b := by
+  by_cases ca : a ∈ ids <;> by_cases cb : b ∈ ids
+  · have index : ids.idxOf a = ids.idxOf b := by simpa [renameLocal, ca, cb] using same
+    have ia := List.idxOf_lt_length_of_mem ca
+    have ib := List.idxOf_lt_length_of_mem cb
+    have ea := List.getElem_idxOf ia
+    have eb := List.getElem_idxOf ib
+    have ea' : ids[ids.idxOf b] = a := by simpa only [index] using ea
+    exact ea'.symm.trans eb
+  · have := (rename_local_fresh ids fresh a ca).1
+    rw [rename_local_shared ids fresh b cb] at same
+    omega
+  · have := (rename_local_fresh ids fresh b cb).1
+    rw [rename_local_shared ids fresh a ca] at same
+    omega
+  · simpa [renameLocal, ca, cb] using same
+
+/-- Different activation intervals cannot share a freshly renamed delimiter. -/
+theorem activation_intervals_are_disjoint (template : Stack A r a s b) (fresh a b : Nat)
+    (ca : a ∈ template.attachments) (cb : b ∈ template.attachments) :
+    renameLocal template.attachments fresh a ≠
+      renameLocal template.attachments (template.activate fresh).2 b := by
+  have left := (rename_local_fresh template.attachments fresh a ca).2
+  have right := (rename_local_fresh template.attachments (template.activate fresh).2 b cb).1
+  simp only [Stack.activate] at right ⊢
+  omega
+
+theorem stack_below_append (first : Stack A r a s b) (after : Stack A s b t c) (fresh : Nat) :
+    (first.append after).Below fresh ↔ first.Below fresh ∧ after.Below fresh := by
+  induction first using Stack.spine_induction with
+  | done => simp [Stack.append, Stack.Below]
+  | push frame rest ih => simp [Stack.append, Stack.Below, ih, and_assoc]
+
+theorem stack_below_mono (stack : Stack A r a s b) (bound : stack.Below before)
+    (grow : before ≤ after) : stack.Below after := by
+  induction stack using Stack.rec
+    (motive_1 := fun _ _ _ _ frame => frame.Below before → frame.Below after) with
+  | bind body env caps => rename_i h; exact fun id member => Nat.lt_of_lt_of_le (h id member) grow
+  | delimiter identity handler env => rename_i h; exact Nat.lt_of_lt_of_le h grow
+  | region | post => trivial
+  | «repeat» template heap arguments acc fold env ih => rename_i h; exact ih h
+  | done => trivial
+  | push frame rest ihFrame ihRest => exact ⟨ihFrame bound.1, ihRest bound.2⟩
+
+theorem stack_rename_bounded (stack : Stack A r a s b) (rename : Nat → Nat)
+    (bound : stack.Below before) (maps : ∀ id, id < before → rename id < after) :
+    (stack.rename rename).Below after := by
+  induction stack using Stack.rec
+    (motive_1 := fun _ _ _ _ frame => frame.Below before → (frame.rename rename).Below after) with
+  | bind body env caps =>
+    rename_i h
+    intro id member
+    simp only [Vector.toList_map] at member
+    obtain ⟨original, present, rfl⟩ := List.mem_map.mp member
+    exact maps original (h original present)
+  | delimiter identity handler env => rename_i h; exact maps identity h
+  | region | post => trivial
+  | «repeat» template heap arguments acc fold env ih => rename_i h; exact ih h
+  | done => trivial
+  | push frame rest ihFrame ihRest => exact ⟨ihFrame bound.1, ihRest bound.2⟩
+
+theorem activation_preserves_attachment_bound (template : Stack A r a s b)
+    (bound : template.Below fresh) : (template.activate fresh).1.Below (template.activate fresh).2 :=
+  stack_rename_bounded template _ bound (rename_local_bounded template.attachments fresh)
+
+theorem capture_preserves_attachment_bound (selected : Selected A r a s b) (mode : Mode)
+    (bound : selected.whole.Below fresh) : (selected.capture mode).Below fresh := by
+  have parts : selected.inside.Below fresh ∧ selected.identity < fresh ∧ selected.outsideStack.Below fresh := by
+    simpa [Selected.whole, stack_below_append, Stack.Below, Frame.Below] using bound
+  cases mode with
+  | deep => simpa [Selected.capture, stack_below_append, Stack.Below, Frame.Below] using And.intro parts.1 parts.2.1
+  | shallow => exact parts.1
+
+def Focus.Below (fresh : Nat) : Focus A regions a → Prop
+  | .code _ _ caps => NamesBelow fresh caps.toList
+  | .value _ => True
+
+def Status.Below (fresh : Nat) : Status A outside result → Prop
+  | .running position => position.focus.Below fresh ∧ position.stack.Below fresh
+  | .pending item => item.identity < fresh ∧ item.stack.Below fresh
+  | .transferred item => item.identity < fresh ∧ item.stack.Below fresh
+  | .returned _ | .disposed => True
+
+/-- Separate from linear custody: the next allocation supply is above all
+reachable attachment names, including aliases inside reusable templates. This
+is not a complete serialized-graph admission or delimiter-uniqueness predicate. -/
+def Machine.AttachmentsBounded (machine : Machine A outside result) : Prop :=
+  machine.status.Below machine.freshAttachment
+
+theorem initial_reserves_attachments (body : Flow A 0 caps [] result)
+    (capabilities : Capabilities caps) (fresh : Nat) :
+    (initial body capabilities fresh).AttachmentsBounded :=
+  ⟨reserve_attachments_above capabilities.toList fresh, True.intro⟩
+
+theorem return_preserves_attachment_bound (eval : Evaluator A) (machine : Machine A outside result)
+    (value : Value a) (heap : Heap regions) (stack : Stack A regions a outside result)
+    (bound : stack.Below machine.freshAttachment) :
+    (returnValue eval machine value heap stack).AttachmentsBounded := by
+  cases stack with
+  | done => trivial
+  | push frame rest =>
+    cases frame with
+    | bind => exact bound
+    | delimiter | post => exact ⟨True.intro, bound.2⟩
+    | region => cases heap; exact ⟨True.intro, bound.2⟩
+    | «repeat» template frozen arguments acc fold env =>
+      cases arguments with
+      | nil => exact ⟨True.intro, bound.2⟩
+      | cons argument arguments =>
+        have grow : machine.freshAttachment ≤ (template.activate machine.freshAttachment).2 := by
+          simp [Stack.activate]
+        exact ⟨True.intro, (stack_below_append _ _ _).mpr
+          ⟨activation_preserves_attachment_bound template bound.1,
+            stack_below_mono template bound.1 grow, stack_below_mono rest bound.2 grow⟩⟩
+
+theorem dispatch_preserves_attachment_bound (eval : Evaluator A) (machine : Machine A outside result)
+    (payload : Nat) (heap : Heap regions) (selected : Selected A regions .number outside result)
+    (bound : selected.whole.Below machine.freshAttachment) :
+    (dispatch eval machine payload heap selected).AttachmentsBounded := by
+  have parts : selected.inside.Below machine.freshAttachment ∧ selected.identity < machine.freshAttachment ∧
+      selected.outsideStack.Below machine.freshAttachment := by
+    simpa [Selected.whole, stack_below_append, Stack.Below, Frame.Below] using bound
+  cases clause : selected.handler.clause with
+  | dispose => simpa only [dispatch, clause, Machine.AttachmentsBounded, Status.Below, Focus.Below] using And.intro True.intro parts.2.2
+  | once mode argument post =>
+    simp only [dispatch, clause, Machine.AttachmentsBounded, Status.Below, Focus.Below]
+    exact ⟨True.intro, (stack_below_append _ _ _).mpr
+      ⟨capture_preserves_attachment_bound selected mode bound, True.intro, parts.2.2⟩⟩
+  | multi mode arguments seed fold =>
+    have captured := capture_preserves_attachment_bound selected mode bound
+    simp only [dispatch, clause]
+    split
+    · exact ⟨True.intro, parts.2.2⟩
+    · have grow : machine.freshAttachment ≤ ((selected.capture mode).activate machine.freshAttachment).2 := by
+        simp [Stack.activate]
+      exact ⟨True.intro, (stack_below_append _ _ _).mpr
+        ⟨activation_preserves_attachment_bound (selected.capture mode) captured,
+          stack_below_mono _ captured grow, stack_below_mono _ parts.2.2 grow⟩⟩
+
+theorem tick_preserves_attachment_bound (eval : Evaluator A) (machine : Machine A outside result)
+    (bound : machine.AttachmentsBounded) : (tick eval machine).AttachmentsBounded := by
+  cases state : machine.status with
+  | pending | returned | disposed | transferred => simpa [tick, state] using bound
+  | running position =>
+    have parts : position.focus.Below machine.freshAttachment ∧ position.stack.Below machine.freshAttachment := by
+      simpa [Machine.AttachmentsBounded, state, Status.Below] using bound
+    rcases position with ⟨regions, input, focus, heap, stack⟩
+    cases focus with
+    | value value =>
+      simpa [tick, state] using return_preserves_attachment_bound eval machine value heap stack parts.2
+    | code expression env caps =>
+      cases expression with
+      | pure | read | write =>
+        simpa [tick, state, Machine.AttachmentsBounded, Status.Below, Focus.Below] using parts.2
+      | bind =>
+        simpa [tick, state, Machine.AttachmentsBounded, Status.Below, Focus.Below, Stack.Below, Frame.Below] using
+          And.intro parts.1 (And.intro parts.1 parts.2)
+      | branch condition yes no =>
+        simpa only [tick, state, Machine.AttachmentsBounded, Status.Below, Focus.Below] using parts
+      | region =>
+        simpa only [tick, state, Machine.AttachmentsBounded, Status.Below, Focus.Below, Stack.Below, Frame.Below] using
+          And.intro parts.1 (And.intro True.intro parts.2)
+      | handle handler body =>
+        have capsBound : NamesBelow (machine.freshAttachment + 1) caps.toList :=
+          fun id member => Nat.lt_succ_of_lt (parts.1 id member)
+        simp only [tick, state, Machine.AttachmentsBounded, Status.Below, Focus.Below, Stack.Below, Frame.Below]
+        refine ⟨?_, Nat.lt_succ_self _, stack_below_mono stack parts.2 (by omega)⟩
+        simpa [NamesBelow] using And.intro (Nat.lt_succ_self machine.freshAttachment) capsBound
+      | perform index payload =>
+        have capability : caps[index] < machine.freshAttachment := parts.1 _ (by simp)
+        simp only [tick, state]
+        split
+        · exact ⟨capability, parts.2⟩
+        next selected found =>
+          apply dispatch_preserves_attachment_bound
+          rw [selection_reconstructs_stack stack caps[index] selected found]
+          exact parts.2
+
+theorem transition_preserves_attachment_bound (eval : Evaluator A) (machine next : Machine A outside result)
+    (input : Input) (bound : machine.AttachmentsBounded)
+    (step : transition eval machine input = some next) : next.AttachmentsBounded := by
+  cases input with
+  | internal =>
+    have equal : tick eval machine = next := Option.some.inj step
+    exact equal ▸ tick_preserves_attachment_bound eval machine bound
+  | resume value | dispose | transfer =>
+    cases state : machine.status <;> try simp [transition, state] at step
+    next pending =>
+      have parts : pending.identity < machine.freshAttachment ∧ pending.stack.Below machine.freshAttachment := by
+        simpa [Machine.AttachmentsBounded, state, Status.Below] using bound
+      cases consumed : machine.ownership.consume pending.token with
+      | none => simp [consumed] at step
+      | some after =>
+        simp [consumed] at step
+        subst next
+        first | exact ⟨True.intro, parts.2⟩ | exact True.intro | exact parts
+
+end BoundaryV2.Effects

--- a/semantics/v2/BoundaryV2/EffectsLowering.lean
+++ b/semantics/v2/BoundaryV2/EffectsLowering.lean
@@ -301,10 +301,11 @@ theorem effectful_step_simulation (machine : Machine Expr outside result) (input
       (transition Expr.eval machine input).map compileMachine :=
   map_preserves_transition compileAtom Expr.eval evaluateBlock compile_atom_preserves_evaluation machine input
 
-/-- Equality of the complete observable trace implies weak trace agreement
-after discarding internal transitions. It covers effectful bind, branches,
-deep/shallow capture, both non-tail callers, repeated template activation,
-region reads/writes, and residual linear resume/dispose/transfer. -/
+/-- Equality of state-observation samples for every finite input script. This
+API samples parked states again on internal polls; it is not an event stream.
+`EffectsTrace.driveEvents` separately proves event-trace preservation and
+silence of parked polling. Both cover effectful bind, branches, deep/shallow
+capture, non-tail callers, repeated templates, regions, and residual custody. -/
 theorem effectful_trace_simulation (machine : Machine Expr outside result) (inputs : List Input) :
     drive evaluateBlock (compileMachine machine) inputs =
       (drive Expr.eval machine inputs).map (fun (last, trace) => (compileMachine last, trace)) :=

--- a/semantics/v2/BoundaryV2/EffectsTrace.lean
+++ b/semantics/v2/BoundaryV2/EffectsTrace.lean
@@ -1,0 +1,135 @@
+import BoundaryV2.EffectsIdentity
+import BoundaryV2.EffectsLowering
+
+namespace BoundaryV2.Effects
+
+open Core Control
+
+/-- `drive` remains a state-sampling trace. Event traces instead record a newly
+exposed request/result, or an external disposition. Polling a parked machine
+is not another request. Equal payloads from distinct operations are not deduped. -/
+def eventAfter (before : Machine A outside result) (input : Input)
+    (next : Machine A outside result) : Option (Observation result) :=
+  match input, before.status with
+  | .internal, .running _ => observe next
+  | .dispose, .pending _ => observe next
+  | .transfer, .pending _ => observe next
+  | _, _ => none
+
+def driveEvents (eval : Evaluator A) (machine : Machine A outside result) :
+    List Input → Option (Machine A outside result × List (Observation result))
+  | [] => some (machine, [])
+  | input :: inputs => do
+    let next ← transition eval machine input
+    let (last, trace) ← driveEvents eval next inputs
+    return (last, (eventAfter machine input next).toList ++ trace)
+
+theorem parked_internal_is_silent (eval : Evaluator A) (machine : Machine A outside result)
+    (parked : observe machine ≠ none) (inputs : List Input) :
+    driveEvents eval machine (.internal :: inputs) = driveEvents eval machine inputs := by
+  cases state : machine.status with
+  | running => simp [observe, state] at parked
+  | pending | returned | disposed | transferred =>
+    simp [driveEvents, transition, tick, state, eventAfter]
+    cases driveEvents eval machine inputs <;> rfl
+
+theorem parked_polling_preserves_event_trace (eval : Evaluator A) (machine : Machine A outside result)
+    (parked : observe machine ≠ none) (count : Nat) (inputs : List Input) :
+    driveEvents eval machine (List.replicate count .internal ++ inputs) = driveEvents eval machine inputs := by
+  induction count with
+  | zero => rfl
+  | succ count ih =>
+    simpa only [List.replicate_succ, List.cons_append,
+      parked_internal_is_silent eval machine parked] using ih
+
+theorem map_preserves_events (translate : Translation A B) (before next : Machine A outside result)
+    (input : Input) :
+    eventAfter (before.map translate) input (next.map translate) = eventAfter before input next := by
+  cases input <;> cases state : before.status <;>
+    simp only [eventAfter, Machine.map, Status.map, state] <;>
+    first | rfl | exact map_preserves_observation translate next
+
+theorem map_preserves_event_trace (translate : Translation A B) (source : Evaluator A) (target : Evaluator B)
+    (compatible : PreservesEvaluation translate source target) (machine : Machine A outside result) (inputs : List Input) :
+    driveEvents target (machine.map translate) inputs =
+      (driveEvents source machine inputs).map (fun (last, trace) => (last.map translate, trace)) := by
+  induction inputs generalizing machine with
+  | nil => rfl
+  | cons input inputs ih =>
+    simp only [driveEvents, map_preserves_transition translate source target compatible]
+    cases step : transition source machine input with
+    | none => rfl
+    | some next =>
+      change (do
+        let pair ← driveEvents target (next.map translate) inputs
+        pure (pair.1, (eventAfter (machine.map translate) input (next.map translate)).toList ++ pair.2)) =
+        (do
+          let pair ← driveEvents source next inputs
+          pure (pair.1, (eventAfter machine input next).toList ++ pair.2)).map
+            (fun (pair : Machine A outside result × List (Observation result)) => (pair.1.map translate, pair.2))
+      rw [ih, map_preserves_events]
+      cases driveEvents source next inputs <;> rfl
+
+theorem effectful_event_trace_simulation (machine : Machine Expr outside result) (inputs : List Input) :
+    driveEvents evaluateBlock (compileMachine machine) inputs =
+      (driveEvents Expr.eval machine inputs).map (fun (last, trace) => (compileMachine last, trace)) :=
+  map_preserves_event_trace compileAtom Expr.eval evaluateBlock compile_atom_preserves_evaluation machine inputs
+
+theorem map_preserves_stack_bound (translate : Translation A B) (stack : Stack A r a s b) (fresh : Nat) :
+    (stack.map translate).Below fresh ↔ stack.Below fresh := by
+  induction stack using Stack.rec
+    (motive_1 := fun _ _ _ _ frame => (frame.map translate).Below fresh ↔ frame.Below fresh) with
+  | bind | delimiter | region | post | done => rfl
+  | «repeat» template heap arguments acc fold env ih => exact ih
+  | push frame rest ihFrame ihRest => simp only [Stack.map, Stack.Below, ihFrame, ihRest]
+
+theorem map_preserves_attachment_bound (translate : Translation A B) (machine : Machine A outside result) :
+    (machine.map translate).AttachmentsBounded ↔ machine.AttachmentsBounded := by
+  cases state : machine.status with
+  | running position =>
+    rcases position with ⟨regions, input, focus, heap, stack⟩
+    cases focus <;>
+      simp [Machine.AttachmentsBounded, Machine.map, Status.map, state, Status.Below,
+        Position.map, Focus.map, Focus.Below, map_preserves_stack_bound]
+  | pending | returned | disposed | transferred =>
+    simp [Machine.AttachmentsBounded, Machine.map, Status.map, state, Status.Below,
+      Pending.map, map_preserves_stack_bound]
+
+theorem drive_preserves_attachment_bound (eval : Evaluator A) (machine last : Machine A outside result)
+    (inputs : List Input) (trace : List (Observation result)) (bound : machine.AttachmentsBounded)
+    (run : drive eval machine inputs = some (last, trace)) : last.AttachmentsBounded := by
+  induction inputs generalizing machine last trace with
+  | nil => simp [drive] at run; exact run.1 ▸ bound
+  | cons input inputs ih =>
+    cases step : transition eval machine input with
+    | none => simp [drive, step] at run
+    | some next =>
+      cases later : drive eval next inputs with
+      | none => simp [drive, step, later] at run
+      | some pair =>
+        rcases pair with ⟨finalState, finalTrace⟩
+        simp [drive, step, later] at run
+        exact run.1 ▸ ih next finalState finalTrace
+          (transition_preserves_attachment_bound eval machine next input bound step) later
+
+theorem event_drive_preserves_invariants (eval : Evaluator A) (machine last : Machine A outside result)
+    (inputs : List Input) (trace : List (Observation result))
+    (valid : machine.Valid) (bound : machine.AttachmentsBounded)
+    (run : driveEvents eval machine inputs = some (last, trace)) :
+    last.Valid ∧ last.AttachmentsBounded := by
+  induction inputs generalizing machine last trace with
+  | nil => simp [driveEvents] at run; exact run.1 ▸ And.intro valid bound
+  | cons input inputs ih =>
+    cases step : transition eval machine input with
+    | none => simp [driveEvents, step] at run
+    | some next =>
+      cases later : driveEvents eval next inputs with
+      | none => simp [driveEvents, step, later] at run
+      | some pair =>
+        rcases pair with ⟨finalState, finalTrace⟩
+        simp [driveEvents, step, later] at run
+        exact run.1 ▸ ih next finalState finalTrace
+          (transition_preserves_invariants eval machine next input valid step)
+          (transition_preserves_attachment_bound eval machine next input bound step) later
+
+end BoundaryV2.Effects

--- a/semantics/v2/README.md
+++ b/semantics/v2/README.md
@@ -2,9 +2,13 @@
 
 This is a model of Boundary control and lowering, checked with the pinned
 Lean 4.33.1 toolchain and bundled Std. It has no external package dependencies.
-Run `lake build` and `lake env lean Trust.lean` in this directory, or use
-`zig build check-v2-semantics` from the repository. Importing Boundary's
-Zig modules does not execute these commands or require Lean.
+Run `node check.mjs` in this directory, or use `zig build check-v2-semantics`
+from the repository. The gate discovers and builds every module under
+`BoundaryV2/`, rejects build warnings, and enforces the axiom policy below.
+`node check.mjs --self-test` also exercises the gate with isolated mutations;
+Linux CI runs those mutations and the repository aggregate. `lake build` remains
+useful for proof development, but alone does not run the trust gate. Importing
+Boundary's Zig modules does not execute these commands or require Lean.
 
 The artifacts under proof are the Lean definitions here. The production Zig
 compiler and World interpreter are not Lean programs and do not have a checked
@@ -19,7 +23,10 @@ independent source oracle and cross-runtime conformance.
 | Ownership.lean | Fresh/live/spent token invariants; consumption preserves disjoint unique ownership; a consumed token cannot resume again; multi activations obtain distinct control identities; lexical region entry and checked exit preserve scope. |
 | Regions.lean | Immutable local-cell templates; consistently renamed local references; reads from current outer storage; alias and scope preservation; distinct names under disjoint fresh maps; multi activation preserves scope and ownership; freezing consumes the original token. |
 | Effects.lean | A complete finite effectful machine: effects on either side of bind, branches, explicit capability environments, nested deep/shallow handlers, non-tail clause callers, immutable multi templates, region reads/writes, and residual resume/dispose/transfer. `machine_progress`, `tick_preserves_invariants`, and `transition_preserves_invariants` cover every control constructor. |
-| EffectsLowering.lean | All embedded lexical expressions compile into first-order instruction blocks, including expressions in dormant nested templates. `effectful_step_simulation` and `effectful_trace_simulation` preserve transitions and complete finite observable traces. `drive_preserves_invariants` extends ownership preservation to any accepted external script. |
+| EffectsLowering.lean | All embedded lexical expressions compile into first-order instruction blocks, including expressions in dormant nested templates. `effectful_step_simulation` and `effectful_trace_simulation` preserve transitions and finite state-observation samples (including repeated parked observations). `drive_preserves_invariants` extends ownership preservation to any accepted external script. |
+| EffectsIdentity.lean | Selection reconstructs the actual effectful stack, uses the requested identity, and stops at its nearest delimiter. Initialization reserves above ambient capabilities. Internal and accepted external transitions preserve the attachment supply bound through active stacks and dormant templates. Local renaming is injective on the old bounded identity domain and successive allocation intervals are disjoint. |
+| EffectsTrace.lean | `driveEvents` records newly exposed events rather than polling samples. Arbitrarily many parked internal polls are silent. Compilation preserves these event traces, while accepted scripts preserve both custody and attachment bounds. The original sampling API is unchanged. |
+| EffectsChecks.lean | Kernel-checked regressions distinguish ambient capabilities from newly installed handlers, exercise dormant aliases and successive activation intervals, retain separate requests with equal payloads, and emit disposal/transfer only once. Source and compiled executions agree. |
 | EffectsExamples.lean | Kernel reductions establish deep/non-tail result 114, shallow/non-tail result 104, direct operation-clause answer 7, the two State/Choice results `(1,1)` and `(1,2)`, effectful binds across two residual responses, and consumed sender custody on disposal/transfer. Compiled examples independently reduce to the same expected values. |
 
 The planned formal-core inventory is covered by the following construction and
@@ -32,11 +39,20 @@ unchecked-cast alternative. The additional `Machine.Valid` predicate requires
 unique, disjoint live/spent token sets and exact custody: the pending position
 owns the sole live token, and every other state owns none.
 
+`Machine.AttachmentsBounded` is a separate invariant: the next attachment supply
+is strictly above all reachable attachment identities, including saved capability
+environments and dormant nested templates. `initial` derives this bound from the
+ambient capabilities, treating the requested supply as a lower bound. An already
+sufficient supply is unchanged. Every internal transition and accepted external
+action preserves the bound. It is not a complete graph-admission predicate and
+does not assert uniqueness of every simultaneously active delimiter.
+
 | Required formal observation | Evidence |
 | --- | --- |
 | Type, scope, and linear-ownership preservation | Indexed `tick`/`transition` results; `tick_preserves_invariants`, `transition_preserves_invariants`, and `drive_preserves_invariants`. |
 | Progress up to residual effects | `machine_progress`; `live_residual_progress` proves each typed residual disposition has a valid successor. |
-| Simulation into first-order code | `compile_preserves_value_and_scope`, `effectful_step_simulation`, and `effectful_trace_simulation`. |
+| Simulation into first-order code | `compile_preserves_value_and_scope`, `effectful_step_simulation`, `effectful_trace_simulation` (samples), and `effectful_event_trace_simulation` (events). |
+| Attachment allocation | `initial_reserves_attachments`, `tick_preserves_attachment_bound`, `transition_preserves_attachment_bound`, and `drive_preserves_attachment_bound`; compilation preserves the invariant. |
 | Return, bind, deep/shallow handling, non-tail resume | Every corresponding `Flow`/`Frame` constructor participates in the global step/trace proofs; closed examples distinguish the return-clause and non-tail rules. |
 | Regions and linear/multi disposition | `LocalHeap` stores only the captured prefix; `rebasing_preserves_current_outer_heap`; exact one-shot custody and `residual_disposition_consumes_once`; multi activation and nested template remapping are covered by the global simulation. |
 
@@ -47,9 +63,10 @@ resume once, or fold a finite list of reusable resumptions. The control algebra
 is shared by the source and target instantiations. Compilation replaces every
 source expression with typed instruction data; it does not claim a separately
 derived production interpreter or flatten the whole model into BPI2 blocks.
-The natural-number attachment supply must initially be reserved above ambient
-capability identities. The ownership invariant is not a proof of global fresh
-name allocation or of a serialized graph's complete admission rules.
+The checked attachment bounds and finite-renaming laws apply to this model's
+allocator, not to World's production allocator or a serialized graph's complete
+admission rules. The effectful simulation still shares its control algebra;
+there is no checked translation into actual BPI2 control-flow blocks.
 
 The separate `Regions.lean` model uses number-valued cells and explicit local/outer references.
 Fresh-name injectivity and disjointness are hypotheses of the corresponding
@@ -63,12 +80,39 @@ Fixed-width arithmetic faults, recursive application code, arbitrary effectful
 operation clauses, first-class suspension packages, scoped forwarding,
 cleanup/cancellation, graph cycles, canonical wire formats, garbage collection,
 and selective compiler optimizations have separate executable evidence and are
-outside this formal core. Finite script lengths in `drive` and the closed-example
-`ticks` helper are observation horizons; no machine transition reads semantic fuel.
+outside this formal core. Finite script lengths in `drive`, `driveEvents`, and
+the closed-example `ticks` helper are observation horizons; no machine transition
+reads semantic fuel.
 
-`Trust.lean` prints the kernel dependencies of every current theorem. Depending
-on the theorem, these include Lean's standard `propext`, `Quot.sound`, and
-`Classical.choice`; several direct control and renaming laws use no axioms.
+## Samples and events
+
+`drive` retains its original contract: it samples `observe` after each accepted
+input. Polling a pending or terminal machine therefore repeats that observation.
+`driveEvents` instead records an observation when an internal transition from a
+running machine exposes it, or when a pending request is disposed or transferred.
+Internal polls of a parked machine emit nothing. It does not deduplicate by
+payload: two distinct requests with equal identity and payload remain two events.
+Both drivers exclude an implicit initial observation; use `observe` to inspect a
+state before supplying inputs. Invalid external actions still reject.
+
+## Enforced trust policy
+
+`Trust.lean` examines transitive axiom dependencies of every declaration owned
+by a `BoundaryV2` module, including private helpers, definitions, and unused
+axioms outside the `BoundaryV2` namespace. Only `propext`, `Quot.sound`, and
+`Classical.choice` are permitted. An unexpected dependency is a build error,
+not merely a printed report. Declaration/theorem counts include Lean-generated
+helpers and are not counts of handwritten claims.
+
+`check.mjs` discovers modules from the source directory and imports them into a
+temporary audit, so a new file omitted from `BoundaryV2.lean` cannot escape the
+gate. `--self-test` checks a clean orphan module and rejects a private `sorry`,
+an unused custom axiom, a definition using `sorry`, and a `native_decide` proof.
+These probes use isolated temporary copies. Their build warnings are allowed
+only so the tests verify rejection by the axiom policy itself; ordinary builds
+reject warnings. No test mutates the working tree.
+
 There are no custom admitted axioms, unfinished proof placeholders, native
-decision shortcuts, unsafe definitions, or partial definitions in this core.
-The Lean kernel and standard logical axioms are the logical trust boundary.
+decision shortcuts, unsafe definitions, or partial definitions in the formal
+core. The kernel and standard logical axioms are its logical trust boundary.
+The audit is build tooling, not an additional axiom or a proof of the Zig compiler.

--- a/semantics/v2/Trust.lean
+++ b/semantics/v2/Trust.lean
@@ -1,99 +1,26 @@
 import BoundaryV2
+import Lean
 
--- Kernel-checked dependency reports for every theorem in the current core.
-#print axioms BoundaryV2.Control.append_runs_in_order
-#print axioms BoundaryV2.Control.append_done
-#print axioms BoundaryV2.Control.append_associative
-#print axioms BoundaryV2.Control.selection_reconstructs_context
-#print axioms BoundaryV2.Control.selection_uses_capability_identity
-#print axioms BoundaryV2.Control.deep_resume_applies_return_once
-#print axioms BoundaryV2.Control.shallow_resume_does_not_reinstall
-#print axioms BoundaryV2.Control.clause_answer_bypasses_return
-#print axioms BoundaryV2.Control.non_tail_resume_retains_both_continuations
-#print axioms BoundaryV2.Control.operation_progress
-#print axioms BoundaryV2.Control.renamed_context_preserves_value
-#print axioms BoundaryV2.Control.linear_disposition_preserves_ownership
-#print axioms BoundaryV2.Control.linear_disposition_cannot_repeat
-#print axioms BoundaryV2.Control.live_linear_disposition_progress
-#print axioms BoundaryV2.Control.resume_consumes_before_returning_to_clause
-#print axioms BoundaryV2.Control.Target.compiled_block_preserves_value
-#print axioms BoundaryV2.Control.Target.compiled_frame_preserves_value
-#print axioms BoundaryV2.Control.Target.compilation_preserves_composition
-#print axioms BoundaryV2.Control.Target.compiled_context_preserves_value
-#print axioms BoundaryV2.Control.Target.compilation_preserves_selection
-#print axioms BoundaryV2.Control.Target.compilation_preserves_capture
-#print axioms BoundaryV2.Control.Target.compilation_preserves_non_tail_resume
-#print axioms BoundaryV2.Control.Target.return_step_simulation
-#print axioms BoundaryV2.Control.Target.return_trace_simulation
-#print axioms BoundaryV2.Core.code_append_runs_in_order
-#print axioms BoundaryV2.Core.compile_preserves_value_and_scope
-#print axioms BoundaryV2.ownership_empty_valid
-#print axioms BoundaryV2.capture_preserves_ownership
-#print axioms BoundaryV2.consume_preserves_ownership
-#print axioms BoundaryV2.consumed_token_cannot_resume
-#print axioms BoundaryV2.multi_activations_are_distinct
-#print axioms BoundaryV2.multi_activation_preserves_ownership
-#print axioms BoundaryV2.clone_preserves_outer_regions
-#print axioms BoundaryV2.clone_preserves_aliases
-#print axioms BoundaryV2.clone_preserves_distinctions
-#print axioms BoundaryV2.enter_region_preserves_scope
-#print axioms BoundaryV2.exit_region_preserves_scope
-#print axioms BoundaryV2.borrowed_region_cannot_escape
-#print axioms BoundaryV2.Regions.activation_preserves_scope
-#print axioms BoundaryV2.Regions.multi_resume_preserves_ownership_and_scope
-#print axioms BoundaryV2.Regions.successive_multi_resumes_have_distinct_control
-#print axioms BoundaryV2.Regions.freeze_consumes_original_ownership
-#print axioms BoundaryV2.Regions.renamed_read_preserves_frozen_contents
-#print axioms BoundaryV2.Regions.activation_preserves_local_read
-#print axioms BoundaryV2.Regions.activation_observes_current_outer_heap
-#print axioms BoundaryV2.Regions.activation_preserves_computation
-#print axioms BoundaryV2.Regions.activation_preserves_aliases
-#print axioms BoundaryV2.Regions.local_activation_names_are_disjoint
-#print axioms BoundaryV2.Regions.clone_preserves_region_scope
-#print axioms BoundaryV2.Regions.write_preserves_outer_read
-#print axioms BoundaryV2.Regions.write_preserves_reference_aliases
-#print axioms BoundaryV2.Regions.choice_outside_state
-#print axioms BoundaryV2.Regions.state_outside_choice
-#print axioms BoundaryV2.Effects.Stack.spine_induction
-#print axioms BoundaryV2.Effects.finish_capture_is_capture_then_consume
-#print axioms BoundaryV2.Effects.finish_capture_preserves_ownership
-#print axioms BoundaryV2.Effects.initial_is_well_owned
-#print axioms BoundaryV2.Effects.return_preserves_ownership
-#print axioms BoundaryV2.Effects.dispatch_preserves_ownership
-#print axioms BoundaryV2.Effects.tick_preserves_invariants
-#print axioms BoundaryV2.Effects.transition_preserves_invariants
-#print axioms BoundaryV2.Effects.residual_disposition_consumes_once
-#print axioms BoundaryV2.Effects.live_residual_progress
-#print axioms BoundaryV2.Effects.machine_progress
-#print axioms BoundaryV2.Effects.rebasing_preserves_current_outer_heap
-#print axioms BoundaryV2.Effects.map_preserves_composition
-#print axioms BoundaryV2.Effects.map_preserves_outer_heap
-#print axioms BoundaryV2.Effects.map_preserves_freezing
-#print axioms BoundaryV2.Effects.map_preserves_attachments
-#print axioms BoundaryV2.Effects.stack_map_commutes_with_renaming
-#print axioms BoundaryV2.Effects.map_preserves_activation
-#print axioms BoundaryV2.Effects.map_preserves_selection
-#print axioms BoundaryV2.Effects.map_preserves_capture
-#print axioms BoundaryV2.Effects.map_preserves_return_step
-#print axioms BoundaryV2.Effects.map_preserves_dispatch
-#print axioms BoundaryV2.Effects.map_preserves_tick
-#print axioms BoundaryV2.Effects.map_preserves_transition
-#print axioms BoundaryV2.Effects.map_preserves_observation
-#print axioms BoundaryV2.Effects.map_preserves_ownership
-#print axioms BoundaryV2.Effects.drive_preserves_invariants
-#print axioms BoundaryV2.Effects.map_preserves_observable_trace
-#print axioms BoundaryV2.Effects.compile_atom_preserves_evaluation
-#print axioms BoundaryV2.Effects.effectful_step_simulation
-#print axioms BoundaryV2.Effects.effectful_trace_simulation
-#print axioms BoundaryV2.Effects.Examples.deep_non_tail_applies_return_once
-#print axioms BoundaryV2.Effects.Examples.shallow_non_tail_omits_original_return
-#print axioms BoundaryV2.Effects.Examples.compiled_deep_non_tail
-#print axioms BoundaryV2.Effects.Examples.operation_clause_answer_bypasses_return
-#print axioms BoundaryV2.Effects.Examples.choice_outside_state_returns_one_one
-#print axioms BoundaryV2.Effects.Examples.state_outside_choice_returns_one_two
-#print axioms BoundaryV2.Effects.Examples.compiled_state_outside_choice
-#print axioms BoundaryV2.Effects.Examples.effectful_second_bind_reaches_residual
-#print axioms BoundaryV2.Effects.Examples.supplied_responses_return_through_both_binds
-#print axioms BoundaryV2.Effects.Examples.compiled_residual_script
-#print axioms BoundaryV2.Effects.Examples.disposal_terminates_pending_ownership
-#print axioms BoundaryV2.Effects.Examples.transfer_consumes_sender_custody
+/-!
+Enforce the documented logical trust boundary. Select declarations by their
+owning module, not their namespace: this includes private declarations and
+helpers written outside `namespace BoundaryV2`. Inspect every declaration, not
+only a hand-maintained theorem list, so an unused admitted axiom also rejects.
+`check.mjs` imports every source module, including modules not yet in the root.
+-/
+run_cmd do
+  let env ← Lean.getEnv
+  let mut declarations := 0
+  let mut theorems := 0
+  for (name, info) in env.constants.toList do
+    let some index := env.getModuleIdxFor? name | continue
+    let some owner := env.allImportedModuleNames[index.toNat]? |
+      throwError "trust audit: missing owning module for {name}"
+    unless (`BoundaryV2).isPrefixOf owner do continue
+    declarations := declarations + 1
+    if info matches .thmInfo _ then theorems := theorems + 1
+    for axiomName in (← Lean.collectAxioms name) do
+      unless #[`propext, `Quot.sound, `Classical.choice].contains axiomName do
+        throwError "trust audit: unapproved axiom {axiomName} in {name} (module {owner})"
+  if theorems == 0 then throwError "trust audit: no BoundaryV2 theorems discovered"
+  logInfo m!"trust audit: checked {declarations} declarations ({theorems} theorems); only propext, Quot.sound, Classical.choice permitted"

--- a/semantics/v2/Trust.lean
+++ b/semantics/v2/Trust.lean
@@ -23,4 +23,4 @@ run_cmd do
       unless #[`propext, `Quot.sound, `Classical.choice].contains axiomName do
         throwError "trust audit: unapproved axiom {axiomName} in {name} (module {owner})"
   if theorems == 0 then throwError "trust audit: no BoundaryV2 theorems discovered"
-  logInfo m!"trust audit: checked {declarations} declarations ({theorems} theorems); only propext, Quot.sound, Classical.choice permitted"
+  Lean.logInfo m!"trust audit: checked {declarations} declarations ({theorems} theorems); only propext, Quot.sound, Classical.choice permitted"

--- a/semantics/v2/check.mjs
+++ b/semantics/v2/check.mjs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Boundary contributors. MIT license.
+// The proof gate discovers modules; Trust.lean discovers their declarations.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const project = fileURLToPath(new URL('.', import.meta.url));
+
+function modulesIn(directory, prefix = ['BoundaryV2']) {
+  const modules = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) throw new Error(`proof source must not be a symlink: ${entry.name}`);
+    if (entry.isDirectory()) modules.push(...modulesIn(join(directory, entry.name), [...prefix, entry.name]));
+    else if (entry.isFile() && entry.name.endsWith('.lean')) {
+      const parts = [...prefix, entry.name.slice(0, -5)];
+      if (!parts.every(part => /^[A-Za-z_][A-Za-z0-9_]*$/.test(part))) {
+        throw new Error(`unsupported Lean module path: ${parts.join('/')}`);
+      }
+      modules.push(parts.join('.'));
+    }
+  }
+  return modules;
+}
+
+function lake(directory, args) {
+  const result = spawnSync('lake', args, { cwd: directory, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  if (result.error) throw result.error;
+  if (result.signal) throw new Error(`lake terminated by ${result.signal}`);
+  return result;
+}
+
+function output(result) { return `${result.stdout ?? ''}${result.stderr ?? ''}`; }
+function accepted(result) {
+  if (result.status !== 0) throw new Error(output(result) || `lake exited ${result.status}`);
+  return output(result);
+}
+
+function audit(directory, mutation = false) {
+  const modules = ['BoundaryV2', ...modulesIn(join(directory, 'BoundaryV2'))];
+  if (modules.length === 1) throw new Error('no formal-core source modules discovered');
+  // Explicit module targets ensure an orphan file is compiled even if the root
+  // module does not import it. Lean, not a regex over source, inventories proofs.
+  accepted(lake(directory, [...(mutation ? [] : ['--wfail']), 'build', ...modules.map(name => `+${name}`)]));
+  mkdirSync(join(directory, '.lake'), { recursive: true });
+  const scratch = mkdtempSync(join(directory, '.lake', 'trust-'));
+  try {
+    const file = join(scratch, 'Audit.lean');
+    const imports = modules.map(name => `import ${name}`).join('\n');
+    writeFileSync(file, `${imports}\n${readFileSync(join(directory, 'Trust.lean'), 'utf8')}`);
+    return lake(directory, ['env', 'lean', '-DwarningAsError=true', file]);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+function selfTest() {
+  // Each probe is intentionally absent from BoundaryV2.lean and uses a different
+  // namespace. Mutants live only in isolated copies, never in the user's tree.
+  const probes = [
+    ['clean orphan', 'namespace Elsewhere\ntheorem checked : True := by trivial\nend Elsewhere\n', false],
+    ['private sorry', 'namespace Elsewhere\nprivate theorem unfinished : True := by sorry\nend Elsewhere\n', true],
+    ['unused axiom', 'namespace Elsewhere\naxiom invented : False\nend Elsewhere\n', true],
+    ['definition sorry', 'namespace Elsewhere\ndef unfinished : Nat := by sorry\nend Elsewhere\n', true],
+    ['native decision', 'namespace Elsewhere\ntheorem native : (List.range 100).length = 100 := by native_decide\nend Elsewhere\n', true],
+  ];
+  for (const [label, source, reject] of probes) {
+    const copy = mkdtempSync(join(tmpdir(), 'boundary-trust-'));
+    try {
+      cpSync(project, copy, { recursive: true, filter: path => !relative(project, path).split(sep).includes('.lake') });
+      writeFileSync(join(copy, 'BoundaryV2', 'TrustProbe.lean'), `import Std\n${source}`);
+      // Mutants must reach the axiom audit, not merely fail the warning gate.
+      const result = audit(copy, true);
+      if (reject) {
+        assert.notEqual(result.status, 0, `${label}: the trust gate accepted a prohibited proof`);
+        assert.match(output(result), /trust audit: unapproved axiom/, `${label}: failed for an unrelated reason`);
+      } else accepted(result);
+      console.log(`trust mutation: ${label}: ${reject ? 'rejected' : 'accepted'}`);
+    } finally {
+      rmSync(copy, { recursive: true, force: true });
+    }
+  }
+}
+
+try {
+  const args = process.argv.slice(2);
+  assert(args.length === 0 || (args.length === 1 && args[0] === '--self-test'),
+    `usage: node ${basename(fileURLToPath(import.meta.url))} [--self-test]`);
+  process.stdout.write(accepted(audit(project)));
+  if (args.length) selfTest();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Strengthen the checked Lean core without changing the production Zig compiler, BPI2 format, or World runtime.

- **Enforced trust policy:** replace the 96-entry printing-only inventory with declaration discovery and a positive axiom allowlist. Discover every `BoundaryV2/` module, including orphan files omitted from the root imports; inspect private helpers, definitions, and unused axioms by owning module rather than namespace. Normal builds reject warnings. Wire the gate into `zig build check-v2-semantics`.
- **Effectful identity guarantees:** reserve the initial attachment supply above ambient capabilities, retaining already-sufficient supplies. Prove actual `Effects.Stack` selection/reconstruction/nearest-delimiter laws, bounded renaming, disjoint activation intervals, and preservation of attachment bounds through all internal and accepted external transitions, dormant templates, compilation, and finite scripts.
- **Event traces:** preserve the original `drive` sampling API and add `driveEvents`. Prove silence of arbitrarily many parked polls, compilation preservation, and custody/attachment-bound preservation. Distinct operations with identical payloads remain separate events.
- **Regression evidence and Linux CI:** add 43 named theorems, including 12 kernel-reduced regression checks; pin the Lean/Zig/Node toolchains and checkout actions. The temporary toolchain-transfer steps used during development are removed from the final workflow.

## Validation

Tested head: `b6e74aec0664652b89e75ea38db8436c5e8b3fc8`.

The complete committed Git tree matches the local Linux validation workspace: `ad573592a585c33bbf1ffab8283244be28f18f59`.

- Local Linux, pinned Lean 4.33.1: `lake --wfail build` and `node semantics/v2/check.mjs --self-test` passed.
- Trust audit: 2,117 declarations / 867 theorem declarations checked. Counts include Lean-generated declarations; there are 139 explicitly named theorems, up from 96.
- Isolated trust probes: a clean orphan module passes; a private `sorry`, unused custom axiom, definition using `sorry`, and native-decision proof all fail specifically at the axiom policy.
- Additional local semantic mutations: removing initial identity reservation, repeating parked events, and omitting dormant-template renaming each cause the formal build to fail. Mutation copies never alter the working tree.
- `git diff --check` passed.
- [Linux CI](https://github.com/tkersey/boundary/actions/runs/34361647539): clean proof build and trust mutations passed; `zig build check-v2 -Doptimize=ReleaseSafe -j2 --summary all` is running with Zig 0.16.0 and Node 26.8.1.

## Compatibility and proof boundary

`Machine.Valid` still means linear custody. `Machine.AttachmentsBounded` is an additional, explicitly separate supply invariant, not a complete serialized-graph admission predicate or a proof of uniqueness of every active delimiter. The initializer signature and already-valid supplies are preserved; deliberately colliding initial supplies are now repaired. The original sampled trace behavior is unchanged.

The simulation still shares its control algebra between source and compiled atoms. This PR does **not** claim verified production BPI2 lowering, production allocator correctness, full ownership-graph admission, cleanup correctness, or World refinement. Those remain separate proof obligations; no placeholder theorems or admitted axioms are added for them.
